### PR TITLE
Fixed authentication to GitHub API.

### DIFF
--- a/parse_review_issues.py
+++ b/parse_review_issues.py
@@ -32,8 +32,7 @@ issueProcess = ProcessIssues(
 )
 
 # Get all issues for approved packages
-# TODO: why is this method using my username??
-issues = issueProcess.return_response("lwasser")
+issues = issueProcess.return_response()
 # breakpoint()
 # Fixed:
 review = issueProcess.parse_issue_header(issues, 12)

--- a/src/pyosmeta/parse_issues.py
+++ b/src/pyosmeta/parse_issues.py
@@ -40,17 +40,16 @@ class ProcessIssues(YamlIO):
 
     # Set up the API endpoint
     # TODO: can i call the API endpoint above
-    def _get_response(self, username):
+    def _get_response(self):
         """
         # Make a GET request to the API endpoint
         """
-        try:
-            print(self.api_endpoint)
-            return requests.get(self.api_endpoint, auth=(username, self.API_TOKEN))
-        except:
-            print(f"Error: API request failed with status code {response.status_code}")
 
-    def return_response(self, username: str) -> list:
+        print(self.api_endpoint)
+        response = requests.get(self.api_endpoint, headers={'Authorization': f'token {self.API_TOKEN}'})
+        return response
+
+    def return_response(self) -> list:
         """
         Deserialize json response to dict and return.
 
@@ -64,7 +63,7 @@ class ProcessIssues(YamlIO):
         list
             List of dict items each containing a review issue
         """
-        response = self._get_response(username)
+        response = self._get_response()
         return response.json()
 
     def _contains_keyword(self, string: str) -> bool:
@@ -252,7 +251,7 @@ class ProcessIssues(YamlIO):
         """
         stats_dict = {}
         # Small script to get the url (normally the docs) and description of a repo!
-        response = requests.get(url)
+        response = requests.get(url, headers={'Authorization': f'token {self.API_TOKEN}'})
 
         # TODO: should this be some sort of try/except how do i catch these
         # Response errors in the best way possible?
@@ -260,6 +259,9 @@ class ProcessIssues(YamlIO):
             print("Can't find: ", url, ". Did the repo url change?")
         elif response.status_code == 403:
             print("Oops you may have hit an API limit. Exiting")
+            print(f"API Response Text: {response.text}")
+            print(f"API Response Headers: {response.headers}")
+            exit()
 
         # Extract the description and homepage URL from the response JSON
         else:
@@ -278,7 +280,7 @@ class ProcessIssues(YamlIO):
         """
         repo_contribs = url + "/contributors"
         # Small script to get the url (normally the docs) and description of a repo!
-        response = requests.get(repo_contribs)
+        response = requests.get(repo_contribs, headers={'Authorization': f'token {self.API_TOKEN}'})
 
         if response.status_code == 404:
             print("Can't find: ", url, ". Did the repo url change?")
@@ -289,7 +291,7 @@ class ProcessIssues(YamlIO):
     def get_last_commit(self, repo: str) -> str:
         """ """
         url = repo + "/commits"
-        response = requests.get(url).json()
+        response = requests.get(url, headers={'Authorization': f'token {self.API_TOKEN}'}).json()
         date = response[0]["commit"]["author"]["date"]
 
         return self._clean_date(date)


### PR DESCRIPTION
I was exploring some of the issues that you had mentioned may be good for the sprint at PyCon today and decided to se what I could do about #6.

I was running into the API limits described in some of the comments.

I believe this is because all of the github api requests are unauthenticated. [One call ](https://github.com/pyOpenSci/update-web-metadata/blob/10bb274b3eefbcb20676044ce25f9dd33988c3a6/src/pyosmeta/parse_issues.py#L49) seems to try and authenticate, but I don't think that the method used is actually supported by Github. The type of authentication attempted also explains [why the username was hardcoded](https://github.com/pyOpenSci/update-web-metadata/blob/10bb274b3eefbcb20676044ce25f9dd33988c3a6/parse_review_issues.py#L35).

Updating each of the `.get()` calls to use the `Authorization` header seemed to resolve the rate limit issues that I was running into while testing.

I also updated the one case where `HTTP 403` was being handled to 1) have a bit more helpful output and 2) actually `exit()` when it says that it will. This only applies in the one case though, so maybe calls to `requests.get()` could be replaced with a new function which makes the request and then can handle any HTTP errors in one place. Authentication may also be able to happen there too.

I removed the `try`\`except` block from the `_get_response` method because it seems to try and catch API errors but the `403`s don't throw a python error. The `response` var will also always be undefined. Overall it seems to me that we would want python errors to propagate upwards rather than be caught. If you'd prefer to keep the block, `except Exception:` would probably be better (though not as good as catching some other specific exception). I believe that `except` alone will catch things like `^C`. 

I'll be sure to stop-in to the sprint, but will be a bit late. Don't hold #6 for me if someone else wanted to work on it.