### PR TITLE
Update ProcessIssue.get_categories()

### DIFF
--- a/parse_review_issues.py
+++ b/parse_review_issues.py
@@ -32,8 +32,7 @@ issueProcess = ProcessIssues(
 )
 
 # Get all issues for approved packages
-# TODO: why is this method using my username??
-issues = issueProcess.return_response("lwasser")
+issues = issueProcess.return_response()
 # breakpoint()
 # Fixed:
 review = issueProcess.parse_issue_header(issues, 12)

--- a/src/pyosmeta/parse_issues.py
+++ b/src/pyosmeta/parse_issues.py
@@ -40,17 +40,16 @@ class ProcessIssues(YamlIO):
 
     # Set up the API endpoint
     # TODO: can i call the API endpoint above
-    def _get_response(self, username):
+    def _get_response(self):
         """
         # Make a GET request to the API endpoint
         """
-        try:
-            print(self.api_endpoint)
-            return requests.get(self.api_endpoint, auth=(username, self.API_TOKEN))
-        except:
-            print(f"Error: API request failed with status code {response.status_code}")
 
-    def return_response(self, username: str) -> list:
+        print(self.api_endpoint)
+        response = requests.get(self.api_endpoint, headers={'Authorization': f'token {self.API_TOKEN}'})
+        return response
+
+    def return_response(self) -> list:
         """
         Deserialize json response to dict and return.
 
@@ -64,7 +63,7 @@ class ProcessIssues(YamlIO):
         list
             List of dict items each containing a review issue
         """
-        response = self._get_response(username)
+        response = self._get_response()
         return response.json()
 
     def _contains_keyword(self, string: str) -> bool:
@@ -252,7 +251,7 @@ class ProcessIssues(YamlIO):
         """
         stats_dict = {}
         # Small script to get the url (normally the docs) and description of a repo!
-        response = requests.get(url)
+        response = requests.get(url, headers={'Authorization': f'token {self.API_TOKEN}'})
 
         # TODO: should this be some sort of try/except how do i catch these
         # Response errors in the best way possible?
@@ -260,6 +259,9 @@ class ProcessIssues(YamlIO):
             print("Can't find: ", url, ". Did the repo url change?")
         elif response.status_code == 403:
             print("Oops you may have hit an API limit. Exiting")
+            print(f"API Response Text: {response.text}")
+            print(f"API Response Headers: {response.headers}")
+            exit()
 
         # Extract the description and homepage URL from the response JSON
         else:
@@ -278,7 +280,7 @@ class ProcessIssues(YamlIO):
         """
         repo_contribs = url + "/contributors"
         # Small script to get the url (normally the docs) and description of a repo!
-        response = requests.get(repo_contribs)
+        response = requests.get(repo_contribs, headers={'Authorization': f'token {self.API_TOKEN}'})
 
         if response.status_code == 404:
             print("Can't find: ", url, ". Did the repo url change?")
@@ -289,7 +291,7 @@ class ProcessIssues(YamlIO):
     def get_last_commit(self, repo: str) -> str:
         """ """
         url = repo + "/commits"
-        response = requests.get(url).json()
+        response = requests.get(url, headers={'Authorization': f'token {self.API_TOKEN}'}).json()
         date = response[0]["commit"]["author"]["date"]
 
         return self._clean_date(date)

--- a/src/pyosmeta/parse_issues.py
+++ b/src/pyosmeta/parse_issues.py
@@ -304,7 +304,7 @@ class ProcessIssues(YamlIO):
 
         return self._clean_date(date)
 
-    def get_categories(self, issue_body_list: list) -> list:
+    def get_categories(self, issue_body_list: list, fmt: bool = True) -> list:
         """Parse through a pyos issue and grab the categories associated
         with a package
 
@@ -339,6 +339,8 @@ class ProcessIssues(YamlIO):
             # elif line.strip().startswith("* Please fill out a pre-submission"):
             #     break
 
+        if fmt:
+            categories = [c.lower().replace(" ", "-") for c in categories]
         return categories
 
 

--- a/src/pyosmeta/parse_issues.py
+++ b/src/pyosmeta/parse_issues.py
@@ -296,7 +296,7 @@ class ProcessIssues(YamlIO):
 
         return self._clean_date(date)
 
-    def get_categories(self, issue_body_list: list, fmt: bool = True) -> list:
+    def get_categories(self, issue_body_list: list) -> list:
         """Parse through a pyos issue and grab the categories associated
         with a package
 
@@ -330,9 +330,6 @@ class ProcessIssues(YamlIO):
                 break
             # elif line.strip().startswith("* Please fill out a pre-submission"):
             #     break
-
-        if fmt:
-            categories = [c.lower().replace(" ","-") for c in categories]
 
         return categories
 

--- a/src/pyosmeta/parse_issues.py
+++ b/src/pyosmeta/parse_issues.py
@@ -46,7 +46,9 @@ class ProcessIssues(YamlIO):
         """
 
         print(self.api_endpoint)
-        response = requests.get(self.api_endpoint, headers={'Authorization': f'token {self.API_TOKEN}'})
+        response = requests.get(
+            self.api_endpoint, headers={"Authorization": f"token {self.API_TOKEN}"}
+        )
         return response
 
     def return_response(self) -> list:
@@ -251,7 +253,9 @@ class ProcessIssues(YamlIO):
         """
         stats_dict = {}
         # Small script to get the url (normally the docs) and description of a repo!
-        response = requests.get(url, headers={'Authorization': f'token {self.API_TOKEN}'})
+        response = requests.get(
+            url, headers={"Authorization": f"token {self.API_TOKEN}"}
+        )
 
         # TODO: should this be some sort of try/except how do i catch these
         # Response errors in the best way possible?
@@ -280,7 +284,9 @@ class ProcessIssues(YamlIO):
         """
         repo_contribs = url + "/contributors"
         # Small script to get the url (normally the docs) and description of a repo!
-        response = requests.get(repo_contribs, headers={'Authorization': f'token {self.API_TOKEN}'})
+        response = requests.get(
+            repo_contribs, headers={"Authorization": f"token {self.API_TOKEN}"}
+        )
 
         if response.status_code == 404:
             print("Can't find: ", url, ". Did the repo url change?")
@@ -291,7 +297,9 @@ class ProcessIssues(YamlIO):
     def get_last_commit(self, repo: str) -> str:
         """ """
         url = repo + "/commits"
-        response = requests.get(url, headers={'Authorization': f'token {self.API_TOKEN}'}).json()
+        response = requests.get(
+            url, headers={"Authorization": f"token {self.API_TOKEN}"}
+        ).json()
         date = response[0]["commit"]["author"]["date"]
 
         return self._clean_date(date)

--- a/src/pyosmeta/parse_issues.py
+++ b/src/pyosmeta/parse_issues.py
@@ -304,14 +304,19 @@ class ProcessIssues(YamlIO):
 
         return self._clean_date(date)
 
-    def get_categories(self, issue_body_list: list, fmt: bool = True) -> list:
+    def get_categories(
+        self, issue_body_list: list[list[str]], fmt: bool = True
+    ) -> list[str]:
         """Parse through a pyos issue and grab the categories associated
         with a package
 
         Parameters
         ----------
-        issue_body_list : list
-            List containing each line in the first comment of the issue
+        issue_body_list : list[list[str]]
+            The first comment from the issue split into lines and then the lines split as by self.parse_comment()
+
+        fmt : bool
+            Applies some formatting changes to the categories to match what is requried for the website.
         """
         # Find the starting index of the section we're interested in
         start_index = None
@@ -326,7 +331,7 @@ class ProcessIssues(YamlIO):
 
         # Iterate through the lines starting at the starting index and grab the relevant text
         cat_matches = ["[x]", "[X]"]
-        categories = []
+        categories: list[str] = []
         for i in range(start_index + 1, len(issue_body_list)):  # 30):
             line = issue_body_list[i][0].strip()
             checked = any([x in line for x in cat_matches])

--- a/src/pyosmeta/parse_issues.py
+++ b/src/pyosmeta/parse_issues.py
@@ -296,7 +296,7 @@ class ProcessIssues(YamlIO):
 
         return self._clean_date(date)
 
-    def get_categories(self, issue_body_list: list) -> list:
+    def get_categories(self, issue_body_list: list, fmt: bool = True) -> list:
         """Parse through a pyos issue and grab the categories associated
         with a package
 
@@ -330,6 +330,9 @@ class ProcessIssues(YamlIO):
                 break
             # elif line.strip().startswith("* Please fill out a pre-submission"):
             #     break
+
+        if fmt:
+            categories = [c.lower().replace(" ","-") for c in categories]
 
         return categories
 


### PR DESCRIPTION
Includes changes from #11.

Adds a `fmt = True` default option to `ProcessIsue.get_catgories()` which formats the categories as described in #6.

Also expands upon the original type-hinting to satisfy Pyright's `strict` mode.

Added `fmt` to the docstring and re-wrote the `issues` docstring to try and be more explicit that it is `list[list[str]]` rather than `list[str]`.