### PR TITLE
reusable workflow for calling scripts

### DIFF
--- a/.github/workflows/run-script.yml
+++ b/.github/workflows/run-script.yml
@@ -1,0 +1,28 @@
+on:
+  workflow_call:
+    inputs:
+      script_name_with_args:
+        required: true
+        type: string
+
+jobs:
+  run_script_job:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check out the code
+        uses: actions/checkout@v3
+      - name: Setup Python
+        uses: actions/setup-python@v4
+      - name: Upgrade pip
+        run: |
+          # install pip=>20.1 to use "pip cache dir"
+          python -m pip install --upgrade pip wheel
+      - name: Install deps
+        run: python -m pip install -r requirements.txt
+      - name: Install package
+        run: python -m pip install -e .
+      - name: Run script from update-web-metadata repo
+        env:
+         GITHUB_TOKEN: ${{secrets.GITHUB_TOKEN}}
+        run: |
+          python ${{ inputs.script_name_with_args }}

--- a/.github/workflows/test-run-script.yml
+++ b/.github/workflows/test-run-script.yml
@@ -1,0 +1,9 @@
+on:
+  push
+
+jobs:
+  test_run_script_job:
+    uses: ./.github/workflows/run-script.yml
+    with:
+      script_name_with_args: parse_review_issues.py
+    secrets: inherit

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -48,7 +48,6 @@ repos:
     rev: 23.3.0
     hooks:
       - id: black
-        language_version: python3.8
 
   - repo: https://github.com/PyCQA/isort
     rev: 5.12.0

--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ API.](https://docs.github.com/en/rest/guides/getting-started-with-the-rest-api?a
 After obtaining a token;
 
 1. Duplicate the `.env-default` file and rename the copy to `.env`
-2. Assign your token to the `API_TOKEN` variable in the `.env` file.
+2. Assign your token to the `GITHUB_TOKEN` variable in the `.env` file.
 
 ## How to run each script
 

--- a/parse-contributors.py
+++ b/parse-contributors.py
@@ -7,7 +7,7 @@ from pyosmeta.file_io import get_api_token
 # TODO: Turn this into a conditional that checks for a .env file and
 # if that doesn't exist then assume it's being run in actions.
 
-API_TOKEN = get_api_token()
+GITHUB_TOKEN = get_api_token()
 
 
 json_files = [
@@ -23,7 +23,7 @@ json_files = [
 web_yaml_path = "https://raw.githubusercontent.com/pyOpenSci/pyopensci.github.io/main/_data/contributors.yml"
 
 # Instantiate contrib object
-processContribs = ProcessContributors(json_files, web_yaml_path, API_TOKEN)
+processContribs = ProcessContributors(json_files, web_yaml_path, GITHUB_TOKEN)
 
 # Returns a list of dict objects with gh usernames (lowercase) as keys
 web_yml_dict = processContribs.load_website_yml()

--- a/parse_review_issues.py
+++ b/parse_review_issues.py
@@ -14,7 +14,7 @@ To run: python3 parse_issue_metadata.py
 from pyosmeta import ProcessIssues
 from pyosmeta.file_io import get_api_token
 
-API_TOKEN = get_api_token()
+GITHUB_TOKEN = get_api_token()
 
 # TODO: looks like sometimes the gh username is the name then @. so i need to create
 # code that looks for the @ and adds the username to ghusername and the rest to the name
@@ -26,7 +26,7 @@ issueProcess = ProcessIssues(
     org="pyopensci",
     repo_name="software-submission",
     label_name="6/pyOS-approved 🚀🚀🚀",
-    API_TOKEN=API_TOKEN,
+    GITHUB_TOKEN=GITHUB_TOKEN,
 )
 
 # Get all issues for approved packages

--- a/src/pyosmeta/contributors.py
+++ b/src/pyosmeta/contributors.py
@@ -12,7 +12,7 @@ from .file_io import YamlIO
 class ProcessContributors(YamlIO):
     # When initializing how do you decide what should be an input
     # attribute vs just something a method accepted when called?
-    def __init__(self, json_files: list, web_yml: str, API_TOKEN: str):
+    def __init__(self, json_files: list, web_yml: str, GITHUB_TOKEN: str):
         """
         Parameters
         ----------
@@ -23,12 +23,12 @@ class ProcessContributors(YamlIO):
         web_yml : str
             A string containing a path to a online website yml file
             This file contains contributor data used to build the website contribs list
-        API_TOKEN : str
+        GITHUB_TOKEN : str
             A string containing your API token needed to access the github API
         """
 
         self.json_files = json_files
-        self.API_TOKEN = API_TOKEN
+        self.GITHUB_TOKEN = GITHUB_TOKEN
         self.web_yml = web_yml
         self.update_keys = [
             "twitter",
@@ -273,7 +273,7 @@ class ProcessContributors(YamlIO):
         """
 
         url = f"https://api.github.com/users/{username}"
-        headers = {"Authorization": f"Bearer {self.API_TOKEN}"}
+        headers = {"Authorization": f"Bearer {self.GITHUB_TOKEN}"}
         response = requests.get(url, headers=headers)
         # TODO: add check here for if credentials are bad
         # if message = Bad credentials

--- a/src/pyosmeta/file_io.py
+++ b/src/pyosmeta/file_io.py
@@ -17,7 +17,7 @@ def get_api_token() -> str:
         The provided API key in the .env file.
     """
     load_dotenv()
-    return os.environ["API_TOKEN"]
+    return os.environ["GITHUB_TOKEN"]
 
 
 @dataclass

--- a/update_reviewers.py
+++ b/update_reviewers.py
@@ -23,7 +23,7 @@ from pyosmeta.contrib_review_meta import UpdateReviewMeta
 from pyosmeta.contributors import ProcessContributors
 from pyosmeta.file_io import get_api_token
 
-API_TOKEN = get_api_token()
+GITHUB_TOKEN = get_api_token()
 
 # Load contributors dict from website (just for now)
 with open("all_contribs.pickle", "rb") as f:
@@ -39,7 +39,7 @@ review_path = "packages.yml"
 # file_obj = YamlIO()
 # review_dict = file_obj.open_yml_file(review_path)
 # contribs = file_obj.open_yml_file(contrib_path)
-process_contribs = ProcessContributors([], [], API_TOKEN)
+process_contribs = ProcessContributors([], [], GITHUB_TOKEN)
 
 # Will see how this works if you can't pass the token...
 updateMeta = UpdateReviewMeta()


### PR DESCRIPTION
This simplifies clients that are calling our scripts here, such as https://github.com/pyOpenSci/pyopensci.github.io/blob/main/.github/workflows/update-packages.yml

It is in response to the path being wrong with a recent effort to update packages, https://github.com/pyOpenSci/pyopensci.github.io/actions/runs/5562999146/jobs/10161656266#step:5:69

```
Notice:  To update, run: pip install --upgrade pip
/home/runner/work/pyopensci.github.io/pyopensci.github.io
python: can't open file '/home/runner/work/pyopensci.github.io/pyopensci.github.io/scripts/parse_issue_metadata.py': [Errno 2] No such file or directory
```

I'm mixed on whether this is the "best" approach. It's nice that it separates the python environment stuff over here, away from the repos that are just web content. At the same time, it pushes us further away from a unified local/remote development workflow.

A different approach is to not use github reusable workflows, and to reorganize this repo a bit to make the scripts be more entry-point friendly, such that after running `pip install`, we would have them accessible by name instead of by path.

This PR changes API_TOKEN to GITHUB_TOKEN to reflect the fact that github actions provides GITHUB_TOKEN for you automatically as a repo-scoped token. It's better practice than a stored secret of a user PAT.