### PR TITLE
Path cleanup and only export yml in final step

### DIFF
--- a/src/pyosmeta/cli/update_contributors.py
+++ b/src/pyosmeta/cli/update_contributors.py
@@ -67,13 +67,6 @@ def main():
     with open("all_contribs.pickle", "wb") as f:
         pickle.dump(web_contribs, f)
 
-    # TODO: clean export yml if from fileio class and used in all three scripts
-    clean_export_yml(web_contribs, "contributors.yml")
 
-
-### ONE TIME REORDER OF WEB YAML ###
-# review[package_name] = {
-#                 key: review[package_name][key] for key in key_order
-#             }
 if __name__ == "__main__":
     main()

--- a/src/pyosmeta/cli/update_review_contribs.py
+++ b/src/pyosmeta/cli/update_review_contribs.py
@@ -23,9 +23,7 @@ To run: update_reviewers
 
 """
 
-
-import pickle
-from typing import Dict, List, Optional, Tuple, Union
+import os
 
 from pyosmeta.contributors import ProcessContributors
 from pyosmeta.file_io import clean_export_yml, load_pickle
@@ -128,8 +126,8 @@ def main():
                     packages[pkg_name][issue_role]["name"] = contribs[gh_user]["name"]
 
     # Export to yaml
-    clean_export_yml(contribs, "contribs.yml")
-    clean_export_yml(packages, "packs.yml")
+    clean_export_yml(contribs, os.path.join("_data", "contributors.yml"))
+    clean_export_yml(packages, os.path.join("_data", "packages.yml"))
 
 
 if __name__ == "__main__":

--- a/src/pyosmeta/cli/update_reviews.py
+++ b/src/pyosmeta/cli/update_reviews.py
@@ -85,9 +85,6 @@ def main():
     with open("all_reviews.pickle", "wb") as f:
         pickle.dump(web_reviews, f)
 
-    # Export and clean final yaml file
-    clean_export_yml(web_reviews, "packages.yml")
-
 
 if __name__ == "__main__":
     main()


### PR DESCRIPTION
This is a tiny set of fixes to ensure the output yml files are added to our website correctly. 