### PR TITLE
Fix: remove date parses running automatically

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -58,6 +58,7 @@ license = { text = "MIT" }
 # These are entry points that allow you to surface specific functionality
 # for a user to run directly from the package.
 [project.scripts] # Optional
+parse-history = "pyosmeta.cli.parse_history:main"
 update-contributors = "pyosmeta.cli.update_contributors:main"
 update-reviews = "pyosmeta.cli.process_reviews:main"
 update-review-teams = "pyosmeta.cli.update_review_teams:main"

--- a/src/pyosmeta/cli/parse_history.py
+++ b/src/pyosmeta/cli/parse_history.py
@@ -1,12 +1,15 @@
 """
-This is a one time script used to add date contrib was added to yaml file.
+This is a script that only needs to be run once.
+
+it:
+
+1. gets a list of all contributors
+2. parses through the commit history (locally) to figure out when they
+were added to the contributor.yml file
+3. then it adds a date_Added key for that person
+
 This will allow us to ensure the yaml file retains order when users are
 highlighted as "new" and also for diff's in git.
-
-# TODO: when we add a new user we will want to also add the date_added.
-this will need to happen
-
-1. In all three cli scripts
 
 """
 
@@ -17,55 +20,61 @@ import git
 
 from pyosmeta.file_io import open_yml_file
 
-base_url = "https://raw.githubusercontent.com/pyOpenSci/"
-web_yaml_path = base_url + "pyopensci.github.io/main/_data/contributors.yml"
 
-web_contribs = open_yml_file(web_yaml_path)
-
-
-def find_name(name: str, a_list: dict[str, str]) -> str:
-    for data in a_list:
-        if name.lower() in data["name"].lower():
-            return data["github_username"]
-
-
-repo_path = os.path.join(
-    "/Users/leahawasser/Documents/GitHub/pyos/", "pyopensci.github.io"
-)
-
-file_path = os.path.join("_data", "contributors.yml")
-
-if not os.path.isfile(os.path.join(repo_path, file_path)):
-    raise ValueError(
-        f"The file '{file_path}' does not exist in the repository."
+def main():
+    base_url = "https://raw.githubusercontent.com/pyOpenSci/"
+    web_yaml_path = (
+        base_url + "pyopensci.github.io/main/_data/contributors.yml"
     )
 
-repo = git.Repo(repo_path)
-all_commits = list(repo.iter_commits("main", paths=file_path))
-all_rev = reversed(all_commits)
+    web_contribs = open_yml_file(web_yaml_path)
 
-# One time fix for ppl with missing gh usernames early on
-contrib_dates = {}
-for commit in all_rev:
-    commit_date = commit.committed_datetime
+    def find_name(name: str, a_list: dict[str, str]) -> str:
+        for data in a_list:
+            if name.lower() in data["name"].lower():
+                return data["github_username"]
 
-    # Extract the content of the file at the specific commit date
-    blob = repo.git.show(f"{commit}:{file_path}")
-    file_contents = blob.splitlines()
-    # Parse through each line and find github_username, add it to list
-    # username:date
-    for line in file_contents:
-        if " name:" in line:
-            name = line.split(":")[1].strip().lower()
+    repo_path = os.path.join(
+        "/Users/leahawasser/Documents/GitHub/pyos/", "pyopensci.github.io"
+    )
 
-        if "github_username:" in line:
-            gh_user = line.split(":")[1].strip().lower()
-            if not gh_user:
-                gh_user = find_name(name, web_contribs)
-            elif gh_user not in contrib_dates.keys():
-                contrib_dates[gh_user] = commit_date.strftime("%Y-%m-%d")
-            continue
+    file_path = os.path.join("_data", "contributors.yml")
 
-# Export to pickle which supports updates after parsing reviews
-with open("contrib_dates.pickle", "wb") as f:
-    pickle.dump(contrib_dates, f)
+    if not os.path.isfile(os.path.join(repo_path, file_path)):
+        raise ValueError(
+            f"The file '{file_path}' does not exist in the repository."
+        )
+
+    repo = git.Repo(repo_path)
+    all_commits = list(repo.iter_commits("main", paths=file_path))
+    all_rev = reversed(all_commits)
+
+    # One time fix for ppl with missing gh usernames early on
+    contrib_dates = {}
+    for commit in all_rev:
+        commit_date = commit.committed_datetime
+
+        # Extract the content of the file at the specific commit date
+        blob = repo.git.show(f"{commit}:{file_path}")
+        file_contents = blob.splitlines()
+        # Parse through each line and find github_username, add it to list
+        # username:date
+        for line in file_contents:
+            if " name:" in line:
+                name = line.split(":")[1].strip().lower()
+
+            if "github_username:" in line:
+                gh_user = line.split(":")[1].strip().lower()
+                if not gh_user:
+                    gh_user = find_name(name, web_contribs)
+                elif gh_user not in contrib_dates.keys():
+                    contrib_dates[gh_user] = commit_date.strftime("%Y-%m-%d")
+                continue
+
+    # Export to pickle which supports updates after parsing reviews
+    with open("contrib_dates.pickle", "wb") as f:
+        pickle.dump(contrib_dates, f)
+
+
+if __name__ == "__main__":
+    main()

--- a/src/pyosmeta/cli/update_contributors.py
+++ b/src/pyosmeta/cli/update_contributors.py
@@ -2,13 +2,10 @@ import argparse
 import pickle
 from datetime import datetime
 
-import pydantic
 from pydantic import ValidationError
 
 from pyosmeta.contributors import PersonModel, ProcessContributors
 from pyosmeta.file_io import create_paths, load_pickle, open_yml_file
-
-print(pydantic.__version__)
 
 # TODO - https://stackoverflow.com
 # /questions/55762673/how-to-parse-list-of-models-with-pydantic
@@ -16,6 +13,7 @@ print(pydantic.__version__)
 
 
 def main():
+    update_dates = False
     update_all = False
     parser = argparse.ArgumentParser(
         description="A CLI script to update pyOpenSci contributors"
@@ -102,13 +100,14 @@ def main():
             all_contribs[user] = PersonModel(**existing)
 
     # One time only - add contrib added date
-    history = load_pickle("contrib_dates.pickle")
+    if update_dates:
+        history = load_pickle("contrib_dates.pickle")
 
-    for user, data in all_contribs.items():
-        try:
-            setattr(data, "date_added", history[user])
-        except KeyError:
-            print(f"Username {user} must be new, skipping")
+        for user, data in all_contribs.items():
+            try:
+                setattr(data, "date_added", history[user])
+            except KeyError:
+                print(f"Username {user} must be new, skipping")
 
     # Export to pickle which supports updates after parsing reviews
     with open("all_contribs.pickle", "wb") as f:


### PR DESCRIPTION
this should fix the current CI failure in the website repo. it makes updating dates across all users optional (and this should only be run locally)