### PR TITLE
Fix contributor count pagination - add per_page=100 to contributors A…

### DIFF
--- a/src/pyosmeta/github_api.py
+++ b/src/pyosmeta/github_api.py
@@ -234,7 +234,8 @@ class GitHubAPI:
         logged, and the method returns None.
         """
         # https://api.github.com/repos/{owner}/{repo}/contributors
-        repo_contribs_url = f"https://api.github.com/repos/{url['owner']}/{url['repo_name']}/contributors"
+        # Add per_page=100 to get maximum contributors per page and reduce API calls
+        repo_contribs_url = f"https://api.github.com/repos/{url['owner']}/{url['repo_name']}/contributors?per_page=100"
         contributors = self._get_response_rest(repo_contribs_url)
 
         if not contributors:


### PR DESCRIPTION
API call

- Resolves issue where contributor counts were capped at 30
- Now fetches all contributors using 100 pagination
- SunPy should show 239 contributors instead of 30
- We may need to debug at lines 236 -246 debug on github_api.py