### PR TITLE
Increase HTTP request timeout to 30 seconds

### DIFF
--- a/src/pyosmeta/utils_clean.py
+++ b/src/pyosmeta/utils_clean.py
@@ -146,7 +146,7 @@ def check_url(url: str) -> bool:
     """
 
     try:
-        response = requests.get(url, timeout=6)
+        response = requests.get(url, timeout=30)
         return response.status_code == 200
     except Exception:  # pragma: no cover
         return False


### PR DESCRIPTION
Increased timeout for HTTP requests from 6 to 30 seconds.

Hopefully this will decrease errors checking websites by allowing more time to respond