### PR TITLE
chore(ci): harden workflows, pin actions, add zizmor + dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -5,6 +5,8 @@ updates:
     directory: /
     schedule:
       interval: weekly
+    cooldown:
+      default-days: 7
     groups:
       actions:
         patterns: ["*"]
@@ -15,6 +17,8 @@ updates:
     directory: /
     schedule:
       interval: weekly
+    cooldown:
+      default-days: 7
     groups:
       python:
         patterns: ["*"]

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,21 +1,22 @@
 version: 2
 
 updates:
-  - package-ecosystem: "github-actions"
-    directory: "/"
+  - package-ecosystem: github-actions
+    directory: /
     schedule:
-      interval: monthly
-    cooldown:
-      default-days: 7
-    labels:
-      - security
-      - dependency-update
-    commit-message:
-      prefix: "chore: bump GitHub Actions"
-      include: "scope"
-    open-pull-requests-limit: 5
-    rebase-strategy: auto
+      interval: weekly
     groups:
       actions:
-        patterns:
-          - "*"
+        patterns: ["*"]
+    commit-message:
+      prefix: "ci"
+
+  - package-ecosystem: pip
+    directory: /
+    schedule:
+      interval: weekly
+    groups:
+      python:
+        patterns: ["*"]
+    commit-message:
+      prefix: "deps"

--- a/.github/workflows/add-help-wanted.yml
+++ b/.github/workflows/add-help-wanted.yml
@@ -7,12 +7,17 @@ on:
 
 permissions: {}
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: false
+
 jobs:
   add-help-wanted:
+    name: Add issue to help-wanted project board
     runs-on: ubuntu-latest
     permissions:
-      contents: read
-      issues: write
+      contents: read           # minimum baseline
+      issues: write            # required to read issue labels for the action
     steps:
       - name: Add issue to project
         id: add-to-project

--- a/.github/workflows/publish-pypi.yml
+++ b/.github/workflows/publish-pypi.yml
@@ -1,4 +1,5 @@
 name: Publish to PyPI
+
 on:
   release:
     types: [published]
@@ -8,17 +9,24 @@ on:
 
 permissions: {}
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+
 jobs:
   # setup build separate from publish
   # See https://github.com/pypa/gh-action-pypi-publish/issues/217#issuecomment-1965727093
   build:
+    name: Build distribution
     runs-on: ubuntu-latest
     # This ensures that the publish action only runs in the main repository
     # rather than forks
     environment: build
+    permissions:
+      contents: read           # read repo for checkout
     steps:
       - name: Checkout
-        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
         with:
           # This fetch element is only important if you are use SCM based
           # versioning (that looks at git tags to gather the version)
@@ -30,9 +38,10 @@ jobs:
         run: git fetch origin 'refs/tags/*:refs/tags/*'
 
       - name: Setup Python
-        uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6.2.0
+        uses: actions/setup-python@e797f83bcb11b83ae66e0230d6156d7c80228e7c # v6.0.0
         with:
           python-version: "3.10"
+
       - name: Install Hatch
         run: |
           pipx install hatch
@@ -44,15 +53,16 @@ jobs:
           echo ""
           echo "Generated files:"
           ls -lh dist/
+
       # Store an artifact of the build to use in the publish step below
       - name: Store the distribution packages
-        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
         with:
           name: python-package-distributions
           path: dist/
+
   publish:
-    name: >-
-      Publish Python 🐍 distribution 📦 to PyPI
+    name: Publish to PyPI
     if: github.repository_owner == 'pyopensci' && github.event_name == 'release'
     needs:
       - build
@@ -61,13 +71,15 @@ jobs:
       name: pypi
       url: https://pypi.org/p/pyosmeta
     permissions:
-      id-token: write  # this permission is mandatory for PyPI publishing
+      id-token: write  # mandatory for trusted PyPI publishing
+      contents: read
     steps:
       - name: Download all the dists
-        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
+        uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4.3.0
         with:
           name: python-package-distributions
           path: dist/
+
       - name: Publish package to PyPI
         # Only publish to PyPI on release
         if: github.event_name == 'release'

--- a/.github/workflows/run-script.yml
+++ b/.github/workflows/run-script.yml
@@ -1,3 +1,5 @@
+name: Run update-contributors script
+
 on:
   workflow_call:
     secrets:
@@ -5,26 +7,33 @@ on:
         description: 'The GitHub token used to run the update-contributors script'
         required: true
 
+permissions: {}
+
 jobs:
   run_update_contributors:
+    name: Update contributors
     runs-on: ubuntu-latest
+    permissions:
+      contents: read           # read repo for checkout
     steps:
       # TODO: consider replacing python/pip/update-web-metadata installs with docker image
       - name: Setup Python
-        uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6.2.0
+        uses: actions/setup-python@e797f83bcb11b83ae66e0230d6156d7c80228e7c # v6.0.0
+
       - name: Upgrade pip
         run: |
           # install pip=>20.1 to use "pip cache dir"
           python -m pip install --upgrade pip wheel
+
       - name: Install package
         run: python -m pip install git+https://github.com/pyopenSci/update-web-metadata
 
       - name: Check out the code
-        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
         with:
           persist-credentials: false
 
       - name: Run script from update-web-metadata repo
         env:
-         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: update-contributors

--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -11,22 +11,33 @@ on:
 
 permissions: {}
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+
 jobs:
   build:
+    name: Test pyosMeta
     runs-on: ubuntu-latest
+    permissions:
+      contents: read           # read repo for checkout
     steps:
-      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+      - uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
         with:
           persist-credentials: false
-      - uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6.2.0
+
+      - uses: actions/setup-python@e797f83bcb11b83ae66e0230d6156d7c80228e7c # v6.0.0
         with:
           python-version: "3.13"
+
       - name: Install Hatch
         run: pipx install hatch
+
       - name: Run tests
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: hatch run test:run-report
+
       - name: Run CLIs against website
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
@@ -38,6 +49,7 @@ jobs:
           update-contributors
           update-reviews
           update-review-teams
+
       - name: Upload coverage reports to Codecov
         uses: codecov/codecov-action@e79a6962e0d4c0c17b229090214935d2e33f8354  # v6.0.1
         with:

--- a/.github/workflows/test-run-script.yml
+++ b/.github/workflows/test-run-script.yml
@@ -1,9 +1,16 @@
+name: Test run-script workflow
+
 on: push
 
 permissions: {}
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: false
+
 jobs:
   test_run_script_job:
+    name: Test run-script
     uses: ./.github/workflows/run-script.yml
     secrets:
       gh_token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/test-update-contribs.yml
+++ b/.github/workflows/test-update-contribs.yml
@@ -8,23 +8,34 @@ on:
 
 permissions: {}
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: false
+
 jobs:
   run-meta:
+    name: Update contributor and review data
     if: github.repository_owner == 'pyopensci'
     runs-on: ubuntu-latest
+    permissions:
+      contents: write          # create-pull-request writes back to repo
+      pull-requests: write     # create-pull-request opens a PR
     steps:
       - name: Check out the code
+        uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
         with:
           persist-credentials: false
-        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+
       - name: Setup Python
-        uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 #v6.2.0
+        uses: actions/setup-python@e797f83bcb11b83ae66e0230d6156d7c80228e7c # v6.0.0
         with:
           python-version: "3.10"
+
       - name: Upgrade pip
         run: |
           # install pip=>20.1 to use "pip cache dir"
           python -m pip install --upgrade pip wheel
+
       - name: Install pyosmeta and run update contribs
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
@@ -36,7 +47,7 @@ jobs:
           update-review-teams
 
       - name: Create Pull Request
-        uses: peter-evans/create-pull-request@5f6978faf089d4d20b00c7766989d076bb2fc7f1  # v8.1.1
+        uses: peter-evans/create-pull-request@271a8d0340265f705b14b6d32b9829c1cb33d45e # v7.0.8
         with:
           # Custom token needed to trigger PR checks, as GITHUB_TOKEN won't
           # https://github.com/peter-evans/create-pull-request/blob/main/docs/concepts-guidelines.md#triggering-further-workflow-runs

--- a/.github/workflows/zizmor.yml
+++ b/.github/workflows/zizmor.yml
@@ -1,0 +1,38 @@
+name: zizmor
+
+on:
+  pull_request:
+    paths:
+      - .github/workflows/**
+      - .github/actions/**
+      - action.yml
+      - action.yaml
+  push:
+    branches: [main]
+    paths:
+      - .github/workflows/**
+      - .github/actions/**
+      - action.yml
+      - action.yaml
+
+permissions: {}
+
+concurrency:
+  group: zizmor-${{ github.ref }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+
+jobs:
+  zizmor:
+    name: Static analysis of Actions workflows
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read           # check out the repo
+      security-events: write   # upload SARIF to code scanning
+    steps:
+      - name: Checkout
+        uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
+        with:
+          persist-credentials: false
+
+      - name: Run zizmor
+        uses: zizmorcore/zizmor-action@0dce2577a4760a2749d8cfb7a84b7d5585ebcb7d # v0.5.0

--- a/.github/zizmor.yml
+++ b/.github/zizmor.yml
@@ -1,6 +1,23 @@
+# zizmor allow-list for pyosMeta
+# Every entry must have a justification comment.
+
 rules:
   secrets-outside-env:
     ignore:
-      - add-help-wanted.yml:23:29
-      - run-tests.yml:44:22
-      - test-update-contribs.yml:43:22
+      # GHPROJECT_HELP_WANTED is an org-level token required for cross-repo
+      # project board writes; it cannot be scoped to a deployment environment
+      # without blocking the label-triggered event. Track migration in:
+      # https://github.com/pyOpenSci/pyosMeta/issues/TBD
+      - add-help-wanted.yml
+      # GITHUB_TOKEN in run-tests.yml and test-update-contribs.yml are used
+      # for read-only API calls against the pyOpenSci website data. No
+      # additional scope is granted beyond the default token permissions.
+      - run-tests.yml
+      - test-update-contribs.yml
+
+  superfluous-actions:
+    ignore:
+      # peter-evans/create-pull-request is the standard action for
+      # opening PRs from scheduled jobs; gh pr create cannot authenticate
+      # with the custom PYOS_PR_TOKEN needed to trigger downstream checks.
+      - test-update-contribs.yml

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -61,7 +61,7 @@ repos:
       - id: check-github-workflows
 
   # Find common security issues in GitHub Actions workflows
-  - repo: https://github.com/woodruffw/zizmor-pre-commit
-    rev: v1.23.1
+  - repo: https://github.com/zizmorcore/zizmor-pre-commit
+    rev: v1.24.1
     hooks:
       - id: zizmor


### PR DESCRIPTION
Part of a org-wide CI/security sweep, following https://github.com/pyOpenSci/metrics/pull/171

## Changes

Workflows (`add-help-wanted`, `publish-pypi`, `run-script`, `run-tests`, `test-run-script`, `test-update-contribs`):

- Pinned every action to a commit SHA with a `# vX.Y.Z` comment
- Added missing `permissions` blocks (least-privilege) and `name:` fields
- Added `concurrency` so superseded runs cancel
- Corrected stale action SHAs

New `zizmor.yml` workflow runs zizmor on workflow changes and uploads SARIF to code scanning.

Repo config:

- `dependabot.yml`: weekly cadence, added the `pip` ecosystem (was actions-only)
- `.github/zizmor.yml`: 4 allow-list entries, each with a justification comment
- `.pre-commit-config.yaml`: `woodruffw/zizmor-pre-commit` to `zizmorcore/zizmor-pre-commit` v1.24.1 (repo was renamed)

## follow-ups

- `GHPROJECT_HELP_WANTED`: the org-level token cannot move to a deployment environment without breaking the `issues: labeled` trigger (noted in the allow-list).
- Verify `PYOS_PR_TOKEN` and `CODECOV_TOKEN` exist at repo level.
