### PR TITLE
fix: make sure we never delete existing gh metrics + move to rest api

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@ See [GitHub releases](https://github.com/pyOpenSci/pyosMeta/releases) page for a
 
 ## [Unreleased]
 
-* Fix: handle GitHub API errors, ensure metadata are overwritten, use REST API for metadata and stop the run early (@lwasser, #384)
+* Fix: handle GitHub 401 and 403 API errors, use REST API for metadata, ensure metadata are updated, and fail on bad api calls (@lwasser, #384)
 * Fix: permissions issue in reusable workflow (@lwasser, #382)
 * Feat: add tqdm progress bar to parse issues workflow & remove community heading noise (@lwasser, #385)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,9 +6,9 @@ See [GitHub releases](https://github.com/pyOpenSci/pyosMeta/releases) page for a
 
 ## [Unreleased]
 
-* Fix: handle GitHub 401 and 403 API errors, use REST API for metadata, ensure metadata are updated, and fail on bad api calls (@lwasser, #384)
+* Fix: handle GitHub 401 and 403 API errors, use REST API for metadata, ensure metadata are updated, and fail on bad API calls (@lwasser, #384)
 * Fix: permissions issue in reusable workflow (@lwasser, #382)
-* Feat: add tqdm progress bar to parse issues workflow & remove community heading noise (@lwasser, #385)
+* Feat: add `tqdm` progress bar to parse issues workflow & remove community heading noise (@lwasser, #385)
 
 ## [v1.7.9] - 2026-08-05
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,8 @@ See [GitHub releases](https://github.com/pyOpenSci/pyosMeta/releases) page for a
 
 ## [Unreleased]
 
-* Fix: permissions issue in reusable workflow
+* Fix: handle GitHub API errors, ensure metadata are overwritten, use REST API for metadata and stop the run early (@lwasser, #384)
+* Fix: permissions issue in reusable workflow (@lwasser, #382)
 
 ## [v1.7.9] - 2026-08-05
 

--- a/src/pyosmeta/cli/process_reviews.py
+++ b/src/pyosmeta/cli/process_reviews.py
@@ -104,6 +104,7 @@ def main():
     # Contrib count is only available via rest api
     logger.info("Getting GitHub metrics for all packages...")
     repo_paths = process_review.get_repo_paths(accepted_reviews)
+    # Grab existing gh metadata from the packages.yml file in the website repo
     existing_gh_meta = get_existing_gh_meta()
     all_reviews = github_api.get_metrics(
         repo_paths, accepted_reviews, existing_gh_meta

--- a/src/pyosmeta/cli/process_reviews.py
+++ b/src/pyosmeta/cli/process_reviews.py
@@ -24,9 +24,60 @@ To run at the CLI: parse_issue_metadata
 
 import pickle
 
+from pydantic import ValidationError
+
 from pyosmeta import ProcessIssues
+from pyosmeta.constants import PACKAGES_RAW_URL
+from pyosmeta.file_io import load_website_yml
 from pyosmeta.github_api import GitHubAPI
 from pyosmeta.logging import logger
+from pyosmeta.models.base import GhMeta
+
+
+def get_existing_gh_meta(url: str = PACKAGES_RAW_URL) -> dict[str, GhMeta]:
+    """Load the currently published packages.yml and pull out the
+    ``gh_meta`` block for each package, keyed by lowercased package name.
+
+    This is used as a fallback so that a failed GitHub API call doesn't
+    wipe out metrics we already collected in a previous run.
+
+    Parameters
+    ----------
+    url : str
+        URL to the live packages.yml file.
+
+    Returns
+    -------
+    dict
+        Mapping of lowercased package name to its last known ``GhMeta``.
+        Packages with no previously saved (or no longer valid) metrics are
+        omitted.
+    """
+    try:
+        existing_packages = load_website_yml("package_name", url)
+    except Exception:
+        logger.error(
+            "Couldn't load the existing packages.yml. Continuing without "
+            "a fallback for any GitHub metrics fetches that fail this run.",
+            exc_info=True,
+        )
+        return {}
+
+    existing_gh_meta = {}
+    for name, pkg in existing_packages.items():
+        if not pkg.get("gh_meta"):
+            continue
+        try:
+            existing_gh_meta[name] = GhMeta(**pkg["gh_meta"])
+        except ValidationError:
+            logger.error(
+                f"Existing gh_meta for {name} in the live packages.yml "
+                "doesn't match the current GhMeta model. Skipping it as a "
+                "fallback.",
+                exc_info=True,
+            )
+
+    return existing_gh_meta
 
 
 def main():
@@ -53,7 +104,10 @@ def main():
     # Contrib count is only available via rest api
     logger.info("Getting GitHub metrics for all packages...")
     repo_paths = process_review.get_repo_paths(accepted_reviews)
-    all_reviews = github_api.get_metrics(repo_paths, accepted_reviews)
+    existing_gh_meta = get_existing_gh_meta()
+    all_reviews = github_api.get_metrics(
+        repo_paths, accepted_reviews, existing_gh_meta
+    )
 
     with open("all_reviews.pickle", "wb") as f:
         pickle.dump(all_reviews, f)

--- a/src/pyosmeta/cli/process_reviews.py
+++ b/src/pyosmeta/cli/process_reviews.py
@@ -31,6 +31,7 @@ from pyosmeta.constants import PACKAGES_RAW_URL
 from pyosmeta.file_io import load_website_yml
 from pyosmeta.github_api import GitHubAPI
 from pyosmeta.logging import logger
+from pyosmeta.models import ReviewModel
 from pyosmeta.models.base import GhMeta
 
 
@@ -38,8 +39,8 @@ def get_existing_gh_meta(url: str = PACKAGES_RAW_URL) -> dict[str, GhMeta]:
     """Load the currently published packages.yml and pull out the
     ``gh_meta`` block for each package, keyed by lowercased package name.
 
-    This is used as a fallback so that a failed GitHub API call doesn't
-    wipe out metrics we already collected in a previous run.
+    Used by ``update_gh_meta`` as a backup when a fresh GitHub API fetch
+    leaves ``gh_meta`` empty. Does not itself apply metrics to reviews.
 
     Parameters
     ----------
@@ -53,6 +54,7 @@ def get_existing_gh_meta(url: str = PACKAGES_RAW_URL) -> dict[str, GhMeta]:
         Packages with no previously saved (or no longer valid) metrics are
         omitted.
     """
+    # TODO: fail fast if packages.yml cannot be loaded (separate follow-up).
     try:
         existing_packages = load_website_yml("package_name", url)
     except Exception:
@@ -80,6 +82,35 @@ def get_existing_gh_meta(url: str = PACKAGES_RAW_URL) -> dict[str, GhMeta]:
     return existing_gh_meta
 
 
+def update_gh_meta(
+    existing_gh_meta: dict[str, GhMeta],
+    reviews: dict[str, ReviewModel],
+) -> dict[str, ReviewModel]:
+    """Fill in missing gh_meta from previously published packages.yml.
+
+    Fresh API data (already on ``review.gh_meta``) wins. If a fetch left
+    ``gh_meta`` as None, reuse the last known ``GhMeta`` for that package.
+    """
+    for pkg_name, review in reviews.items():
+        if review.gh_meta is not None:
+            continue
+
+        previous_metadata = existing_gh_meta.get(pkg_name.lower())
+        if previous_metadata is not None:
+            logger.warning(
+                f"Couldn't refresh GitHub metrics for {pkg_name}. "
+                "Using the previously saved metrics from packages.yml."
+            )
+            review.gh_meta = previous_metadata
+        else:
+            logger.warning(
+                f"No GitHub metrics available for {pkg_name} "
+                "(none saved previously, and this fetch failed)."
+            )
+
+    return reviews
+
+
 def main():
     github_api = GitHubAPI(
         org="pyopensci",
@@ -104,11 +135,10 @@ def main():
     # Contrib count is only available via rest api
     logger.info("Getting GitHub metrics for all packages...")
     repo_paths = process_review.get_repo_paths(accepted_reviews)
-    # Grab existing gh metadata from the packages.yml file in the website repo
+    # Fetch first; gap-fill from packages.yml only where the API left gh_meta empty
     existing_gh_meta = get_existing_gh_meta()
-    all_reviews = github_api.get_metrics(
-        repo_paths, accepted_reviews, existing_gh_meta
-    )
+    all_reviews = github_api.get_metrics(repo_paths, accepted_reviews)
+    all_reviews = update_gh_meta(existing_gh_meta, all_reviews)
 
     with open("all_reviews.pickle", "wb") as f:
         pickle.dump(all_reviews, f)

--- a/src/pyosmeta/cli/process_reviews.py
+++ b/src/pyosmeta/cli/process_reviews.py
@@ -1,13 +1,13 @@
 """
-Script that parses metadata from and issue and adds it to a .yml file for the
+Script that parses metadata from an issue and adds it to a .yml file for the
 website. It also grabs some of the package metadata such as stars,
 last commit, etc.
 
 This script also checks:
-* That each packages documentation is both https compliant and resolves
+* That each package's documentation is both https compliant and resolves
 * If documentation link is broken it removes it.
 * NOTE: we may want to have the website note if docs are not available for a
-package and have a process to followup
+package and have a process to follow-up
 
 Output: packages.yml file containing a list of:
  1. all packages with accepted reviews
@@ -19,7 +19,7 @@ To run at the CLI: parse_issue_metadata
 """
 
 # TODO: if we export files we might want packages.yml and then under_review.yml
-# thus we'd want to add a second input parameters which was file_name
+# thus we'd want to add a second input parameter which was file_name
 # TODO: feature - Create an "under review now" list as well
 
 import pickle

--- a/src/pyosmeta/github_api.py
+++ b/src/pyosmeta/github_api.py
@@ -168,7 +168,10 @@ class GitHubAPI:
 
     @staticmethod
     def _is_rate_limit_exhausted(response) -> bool:
-        """Return True if response headers show the primary rate limit is
+        """Return True if rate limit has been reached.
+        
+        The header is checked for `X-RateLimit-Remaining` to indicate if the
+        primary rate limit is
         fully used up, as opposed to a plain permission-denied 403."""
         return response.headers.get("X-RateLimit-Remaining") == "0"
 

--- a/src/pyosmeta/github_api.py
+++ b/src/pyosmeta/github_api.py
@@ -260,7 +260,7 @@ class GitHubAPI:
 
         return results
 
-def get_metrics(
+    def get_metrics(
         self,
         endpoints: dict[dict[str, str]],
         reviews: dict[str, ReviewModel],

--- a/src/pyosmeta/github_api.py
+++ b/src/pyosmeta/github_api.py
@@ -23,6 +23,16 @@ from pyosmeta.models.base import GhMeta, RepositoryHost
 from .logging import logger
 
 
+class GitHubAPIError(Exception):
+    """Raised for GitHub API errors that should stop the whole metrics run.
+
+    Covers an invalid/expired token (401)
+    and a fully exhausted rate limit (403 with ``X-RateLimit-Remaining: 0``).
+    Both will affect every subsequent API call in the run so we opt to fail
+    fast.
+    """
+
+
 @dataclass
 class GitHubAPI:
     """
@@ -154,6 +164,26 @@ class GitHubAPI:
 
         return f"{base_url}?{'&'.join(params)}"
 
+    @staticmethod
+    def _is_rate_limit_exhausted(response) -> bool:
+        """Return True if response headers show the primary rate limit is
+        fully used up, as opposed to a plain permission-denied 403."""
+        return response.headers.get("X-RateLimit-Remaining") == "0"
+
+    @staticmethod
+    def _format_rate_limit_reset(response) -> str:
+        """Format the X-RateLimit-Reset header (a Unix timestamp) as a
+        human-readable UTC time for clear error logs."""
+        reset_header = response.headers.get("X-RateLimit-Reset")
+        if not reset_header:
+            return "unknown"
+        try:
+            return time.strftime(
+                "%Y-%m-%d %H:%M:%S UTC", time.gmtime(int(reset_header))
+            )
+        except (TypeError, ValueError):
+            return "unknown"
+
     def handle_rate_limit(self, response):
         """
         Handle rate limiting by waiting until the rate limit resets.
@@ -193,26 +223,38 @@ class GitHubAPI:
         results = []
         api_endpoint_url = url
 
-        try:
-            while api_endpoint_url:
-                response = requests.get(
-                    api_endpoint_url,
-                    headers={"Authorization": f"token {self.get_token()}"},
-                )
-                response.raise_for_status()
-                results.extend(response.json())
+        while api_endpoint_url:
+            response = requests.get(
+                api_endpoint_url,
+                headers={"Authorization": f"token {self.get_token()}"},
+            )
 
-                # Handle pagination & rate limiting
-                api_endpoint_url = response.links.get("next", {}).get("url")
-                self.handle_rate_limit(response)
-
-        except requests.HTTPError as exception:
-            if exception.response.status_code == 401:
-                logger.error(
-                    "Unauthorized request. Your token may be expired or invalid. Please refresh your token."
+            if response.status_code == 401:
+                raise GitHubAPIError(
+                    f"401 Unauthorized calling {api_endpoint_url}. Check "
+                    "that GITHUB_TOKEN is valid, unexpired, and has the "
+                    "correct scopes."
                 )
-            else:
-                raise exception
+            if response.status_code == 403:
+                if self._is_rate_limit_exhausted(response):
+                    raise GitHubAPIError(
+                        f"403 rate limit exhausted calling "
+                        f"{api_endpoint_url}. Resets at "
+                        f"{self._format_rate_limit_reset(response)}."
+                    )
+                logger.warning(
+                    "403 Forbidden (permission denied, not rate-limited) "
+                    f"calling {api_endpoint_url}.\n"
+                    f"API Response Text: {response.text}"
+                )
+                break
+
+            response.raise_for_status()
+            results.extend(response.json())
+
+            # Handle pagination & rate limiting
+            api_endpoint_url = response.links.get("next", {}).get("url")
+            self.handle_rate_limit(response)
 
         return results
 
@@ -244,6 +286,7 @@ class GitHubAPI:
             Updated review data with GitHub metrics.
         """
         existing_gh_meta = existing_gh_meta or {}
+        stop_early = False
 
         for pkg_name, owner_repo in endpoints.items():
             review = reviews[pkg_name]
@@ -254,15 +297,25 @@ class GitHubAPI:
                 continue
 
             previous_meta = existing_gh_meta.get(pkg_name.lower())
-            try:
-                new_meta = self.get_repo_meta_github(owner_repo)
-            except Exception:
-                logger.warning(
-                    f"Unexpected error fetching GitHub metrics for {pkg_name}. "
-                    "Treating this package as a failed fetch.",
-                    exc_info=True,
-                )
-                new_meta = None
+
+            new_meta = None
+            if not stop_early:
+                try:
+                    new_meta = self.get_repo_meta_github(owner_repo)
+                except GitHubAPIError as exc:
+                    logger.error(
+                        f"Stopping GitHub metrics run early: {exc} "
+                        "Remaining packages will fall back to previously "
+                        "saved metrics."
+                    )
+                    stop_early = True
+                except Exception:
+                    logger.warning(
+                        f"Unexpected error fetching GitHub metrics for {pkg_name}. "
+                        "Treating this package as a failed fetch.",
+                        exc_info=True,
+                    )
+                    new_meta = None
 
             if new_meta is not None:
                 reviews[pkg_name].gh_meta = new_meta
@@ -317,124 +370,6 @@ class GitHubAPI:
 
         return len(contributors)
 
-    def _get_metrics_graphql(
-        self, repo_info: dict[str, str]
-    ) -> dict[str, Any] | None:
-        """
-        Get GitHub metrics from the GitHub GraphQL API for a single repository.
-
-        Parameters
-        ----------
-        repo_info : dict
-            A dictionary containing the owner and repository name.
-
-        Returns
-        -------
-        Optional[Dict[str, Any]]
-            A dictionary containing the specified GitHub metrics for the repository.
-            Returns None if the repository is not found or access is forbidden.
-
-        Notes
-        -----
-        This method makes a GraphQL call to the GitHub API to retrieve metadata
-        about a pyos reviewed package repository.
-
-        If the repository is not found or access is forbidden, this method returns None.
-        """
-
-        query = """
-        query($owner: String!, $name: String!) {
-            repository(owner: $owner, name: $name) {
-                name
-                description
-                homepageUrl
-                createdAt
-                stargazers {
-                    totalCount
-                }
-                watchers {
-                    totalCount
-                }
-                issues(states: OPEN) {
-                    totalCount
-                }
-                forks {
-                    totalCount
-                }
-                defaultBranchRef {
-                    target {
-                        ... on Commit {
-                            history(first: 1) {
-                                edges {
-                                    node {
-                                        committedDate
-                                    }
-                                }
-                            }
-                        }
-                    }
-                }
-                collaborators {
-                    totalCount
-                }
-            }
-        }
-        """
-
-        variables = {
-            "owner": repo_info["owner"],
-            "name": repo_info["repo_name"],
-        }
-
-        headers = {"Authorization": f"Bearer {self.get_token()}"}
-
-        response = requests.post(
-            "https://api.github.com/graphql",
-            json={"query": query, "variables": variables},
-            headers=headers,
-        )
-
-        if response.status_code == 200:
-            data = response.json()
-            repo_data = data["data"]["repository"]
-
-            if not repo_data:
-                logger.warning(
-                    f"Repository metrics not able to be retrieved (it may not be on GitHub?): {repo_info['owner']}/{repo_info['repo_name']}."
-                )
-                return None
-
-            return {
-                "name": repo_data["name"],
-                "description": repo_data["description"],
-                "documentation": repo_data["homepageUrl"],
-                "created_at": repo_data["createdAt"],
-                "stargazers_count": repo_data["stargazers"]["totalCount"],
-                "watchers_count": repo_data["watchers"]["totalCount"],
-                "open_issues_count": repo_data["issues"]["totalCount"],
-                "forks_count": repo_data["forks"]["totalCount"],
-                "last_commit": repo_data["defaultBranchRef"]["target"][
-                    "history"
-                ]["edges"][0]["node"]["committedDate"],
-            }
-        elif response.status_code == 404:
-            logger.warning(
-                f"Repository not found: {repo_info['owner']}/{repo_info['repo_name']}. Did the repo URL change?"
-            )
-            return None
-        elif response.status_code == 403:
-            logger.warning(
-                f"Oops! You may have hit an API limit for repository: {repo_info['owner']}/{repo_info['repo_name']}.\n"
-                f"API Response Text: {response.text}\n"
-                f"API Response Headers: {response.headers}"
-            )
-            return None
-        else:
-            logger.warning(
-                f"Unexpected HTTP error: {response.status_code} for repository: {repo_info['owner']}/{repo_info['repo_name']}"
-            )
-            return None
-
     def _get_metrics_rest(
         self, repo_info: dict[str, str]
     ) -> dict[str, Any] | None:
@@ -485,11 +420,21 @@ class GitHubAPI:
                 f"Repository not found: {owner}/{repo_name}. Did the repo URL change?"
             )
             return None
+        elif response.status_code == 401:
+            raise GitHubAPIError(
+                f"401 Unauthorized calling {url}. Check that GITHUB_TOKEN "
+                "is valid, unexpired, and has the correct scopes."
+            )
         elif response.status_code == 403:
+            if self._is_rate_limit_exhausted(response):
+                raise GitHubAPIError(
+                    f"403 rate limit exhausted calling {url}. Resets at "
+                    f"{self._format_rate_limit_reset(response)}."
+                )
             logger.warning(
-                f"Oops! You may have hit an API limit for repository: {owner}/{repo_name}.\n"
-                f"API Response Text: {response.text}\n"
-                f"API Response Headers: {response.headers}"
+                "403 Forbidden (permission denied, not rate-limited) for "
+                f"repository: {owner}/{repo_name}.\n"
+                f"API Response Text: {response.text}"
             )
             return None
         else:
@@ -521,9 +466,6 @@ class GitHubAPI:
         requiring org membership or elevated permissions. Contributor count
         is fetched separately via `_get_contrib_count_rest`, since it isn't
         part of the main repo metadata endpoint.
-
-        `_get_metrics_graphql` is kept temporarily as deprecated, non-critical
-        code (see implementation plan Step 6) and is no longer called here.
 
         If the repository is not found or access is forbidden, it returns None.
         """

--- a/src/pyosmeta/github_api.py
+++ b/src/pyosmeta/github_api.py
@@ -38,9 +38,11 @@ class GitHubAPI:
     """
     A class that processes GitHub issues in our peer review process and returns
     metadata about each package.
+
+    This class contains variable that maps the GhMeta fields to the GitHub REST
+    API fields. It also defines the source of the data for each field.
     """
 
-    # Mapping for how GhMeta fields are populated.
     # `contrib_count` is populated separately from the contributors REST endpoint.
     GH_META_REQUIRED_FIELDS = tuple(GhMeta.model_fields.keys())
     GH_META_REST_FIELD_MAP = {
@@ -263,7 +265,7 @@ class GitHubAPI:
 
     def get_metrics(
         self,
-        endpoints: dict[dict[str, str]],
+        endpoints: dict[str, dict[str, str]],
         reviews: dict[str, ReviewModel],
     ) -> dict[str, ReviewModel]:
         """

--- a/src/pyosmeta/github_api.py
+++ b/src/pyosmeta/github_api.py
@@ -30,6 +30,40 @@ class GitHubAPI:
     metadata about each package.
     """
 
+    # Mapping for how GhMeta fields are populated.
+    # `contrib_count` is populated separately from the contributors REST endpoint.
+    GH_META_REQUIRED_FIELDS = tuple(GhMeta.model_fields.keys())
+    GH_META_REST_FIELD_MAP = {
+        "name": "name",
+        "description": "description",
+        "documentation": "homepage",
+        "created_at": "created_at",
+        "stargazers_count": "stargazers_count",
+        "watchers_count": "watchers_count",
+        "open_issues_count": "open_issues_count",
+        "forks_count": "forks_count",
+        "last_commit": "pushed_at",
+    }
+    GH_META_CONTRIB_SOURCE = "GET /repos/{owner}/{repo}/contributors"
+    GH_META_LAST_COMMIT_SOURCE = GH_META_REST_FIELD_MAP["last_commit"]
+
+    @classmethod
+    def get_gh_meta_field_mapping(cls) -> dict[str, Any]:
+        """Return the GhMeta field map and source details.
+
+        Returns
+        -------
+        dict[str, Any]
+            Mapping details describing required output fields and where each
+            field comes from in the REST API payload or endpoint.
+        """
+        return {
+            "required_fields": cls.GH_META_REQUIRED_FIELDS,
+            "rest_field_map": cls.GH_META_REST_FIELD_MAP,
+            "contrib_source": cls.GH_META_CONTRIB_SOURCE,
+            "last_commit_source": cls.GH_META_LAST_COMMIT_SOURCE,
+        }
+
     def __init__(
         self,
         org: str | None = "pyopensci",
@@ -390,6 +424,69 @@ class GitHubAPI:
         else:
             logger.warning(
                 f"Unexpected HTTP error: {response.status_code} for repository: {repo_info['owner']}/{repo_info['repo_name']}"
+            )
+            return None
+
+    def _get_metrics_rest(
+        self, repo_info: dict[str, str]
+    ) -> dict[str, Any] | None:
+        """Get GitHub metadata from the GitHub REST API for a single repository.
+
+        Parameters
+        ----------
+        repo_info : dict
+            A dictionary containing the owner and repository name.
+
+        Returns
+        -------
+        Optional[Dict[str, Any]]
+            A dictionary containing GhMeta-compatible metadata for the
+            repository, normalized using GH_META_REST_FIELD_MAP.
+            Returns None if the repository is not found or access is
+            forbidden.
+
+        Notes
+        -----
+        This method calls GET /repos/{owner}/{repo} to retrieve metadata
+        about a pyos reviewed package repository. `contrib_count` is not
+        included here - it's fetched separately via _get_contrib_count_rest.
+
+        If the repository is not found or access is forbidden, this method
+        returns None.
+        """
+        owner = repo_info["owner"]
+        repo_name = repo_info["repo_name"]
+        url = f"https://api.github.com/repos/{owner}/{repo_name}"
+        headers = {"Authorization": f"Bearer {self.get_token()}"}
+
+        response = requests.get(url, headers=headers)
+
+        if response.status_code == 200:
+            repo_data = response.json()
+            metrics = {
+                gh_meta_field: repo_data.get(rest_field)
+                for gh_meta_field, rest_field in self.GH_META_REST_FIELD_MAP.items()
+            }
+            # GitHub returns an empty string (not null) when no homepage
+            # is set, so normalize that to None for GhMeta.
+            if not metrics.get("documentation"):
+                metrics["documentation"] = None
+            return metrics
+        elif response.status_code == 404:
+            logger.warning(
+                f"Repository not found: {owner}/{repo_name}. Did the repo URL change?"
+            )
+            return None
+        elif response.status_code == 403:
+            logger.warning(
+                f"Oops! You may have hit an API limit for repository: {owner}/{repo_name}.\n"
+                f"API Response Text: {response.text}\n"
+                f"API Response Headers: {response.headers}"
+            )
+            return None
+        else:
+            logger.warning(
+                f"Unexpected HTTP error: {response.status_code} for repository: {owner}/{repo_name}"
             )
             return None
 

--- a/src/pyosmeta/github_api.py
+++ b/src/pyosmeta/github_api.py
@@ -175,8 +175,8 @@ class GitHubAPI:
 
     @staticmethod
     def _format_rate_limit_reset(response) -> str:
-        """Format the X-RateLimit-Reset header (a Unix timestamp) as a
-        human-readable UTC time for clear error logs."""
+        """Format the X-RateLimit-Reset header timestamp to a
+        human-readable UTC time."""
         reset_header = response.headers.get("X-RateLimit-Reset")
         if not reset_header:
             return "unknown"

--- a/src/pyosmeta/github_api.py
+++ b/src/pyosmeta/github_api.py
@@ -254,7 +254,15 @@ class GitHubAPI:
                 continue
 
             previous_meta = existing_gh_meta.get(pkg_name.lower())
-            new_meta = self.get_repo_meta_github(owner_repo)
+            try:
+                new_meta = self.get_repo_meta_github(owner_repo)
+            except Exception:
+                logger.warning(
+                    f"Unexpected error fetching GitHub metrics for {pkg_name}. "
+                    "Treating this package as a failed fetch.",
+                    exc_info=True,
+                )
+                new_meta = None
 
             if new_meta is not None:
                 reviews[pkg_name].gh_meta = new_meta
@@ -493,7 +501,7 @@ class GitHubAPI:
     def get_repo_meta_github(
         self, repo_info: dict[str, str]
     ) -> dict[str, Any] | None:
-        """Get GitHub metrics from the GitHub GraphQL API for a repository.
+        """Get GitHub metadata for a repository, REST-first.
 
         Parameters
         ----------
@@ -508,12 +516,18 @@ class GitHubAPI:
 
         Notes
         -----
-        This method makes a GraphQL call to the GitHub API to retrieve metadata
-        about a pyos reviewed package repository.
+        REST (`_get_metrics_rest`) is the primary and only source used here
+        for repository metadata, so this works with a general token without
+        requiring org membership or elevated permissions. Contributor count
+        is fetched separately via `_get_contrib_count_rest`, since it isn't
+        part of the main repo metadata endpoint.
+
+        `_get_metrics_graphql` is kept temporarily as deprecated, non-critical
+        code (see implementation plan Step 6) and is no longer called here.
 
         If the repository is not found or access is forbidden, it returns None.
         """
-        metrics = self._get_metrics_graphql(repo_info)
+        metrics = self._get_metrics_rest(repo_info)
         if metrics is not None:
             metrics["contrib_count"] = self._get_contrib_count_rest(repo_info)
 

--- a/src/pyosmeta/github_api.py
+++ b/src/pyosmeta/github_api.py
@@ -295,7 +295,7 @@ class GitHubAPI:
             Review data with freshly fetched ``gh_meta`` where the API
             succeeded, or ``None`` where it did not.
         """
-        # if True, metrics run should stop further API fetches
+        # If True, metrics run should stop further API fetches
         stop_metrics_run = False
 
         for pkg_name, owner_repo in tqdm(

--- a/src/pyosmeta/github_api.py
+++ b/src/pyosmeta/github_api.py
@@ -26,7 +26,9 @@ from .logging import logger
 
 
 class GitHubAPIError(Exception):
-    """Raised for GitHub API errors that should stop the whole metrics run.
+    """Raised for GitHub API errors.
+    
+       The usual handling of these errors would be to stop the metrics run.
 
     Covers an invalid/expired token (401)
     and a fully exhausted rate limit (403 with ``X-RateLimit-Remaining: 0``).

--- a/src/pyosmeta/github_api.py
+++ b/src/pyosmeta/github_api.py
@@ -26,14 +26,10 @@ from .logging import logger
 
 
 class GitHubAPIError(Exception):
-    """Raised for GitHub API errors.
-    
-       The usual handling of these errors would be to stop the metrics run.
+    """Raised for GitHub API errors that affect the whole metrics run.
 
-    Covers an invalid/expired token (401)
-    and a fully exhausted rate limit (403 with ``X-RateLimit-Remaining: 0``).
-    Both will affect every subsequent API call in the run so we opt to fail
-    fast.
+    Covers an invalid/expired token (401) and a fully exhausted rate limit
+    (403 with ``X-RateLimit-Remaining: 0``).
     """
 
 
@@ -171,7 +167,7 @@ class GitHubAPI:
     @staticmethod
     def _is_rate_limit_exhausted(response) -> bool:
         """Return True if rate limit has been reached.
-        
+
         The header is checked for `X-RateLimit-Remaining` to indicate if the
         primary rate limit is
         fully used up, as opposed to a plain permission-denied 403."""
@@ -269,11 +265,20 @@ class GitHubAPI:
         self,
         endpoints: dict[dict[str, str]],
         reviews: dict[str, ReviewModel],
-        existing_gh_meta: dict[str, GhMeta] | None = None,
     ) -> dict[str, ReviewModel]:
         """
-        Get GitHub metrics for all reviews using provided repo name and owner.
-        Does not work on GitLab currently
+        Fetch GitHub metrics for all reviews using provided repo name and owner.
+        Does not work on GitLab currently.
+
+        On success, sets ``review.gh_meta`` from the API response (date fields
+        are cleaned via the ``GhMeta`` model). On failure, leaves ``gh_meta``
+        as ``None`` so a separate merge step can gap-fill from previously
+        published packages.yml data.
+
+        If a ``GitHubAPIError`` is raised (401 or exhausted rate-limit 403),
+        further API fetches for remaining packages are stopped
+        (``stop_metrics_run``). Those packages keep ``gh_meta=None`` for the
+        merge step to fill.
 
         Parameters:
         ----------
@@ -281,19 +286,15 @@ class GitHubAPI:
             A dictionary mapping package names to their owner and repo-names.
         reviews : dict
             A dictionary containing review data.
-        existing_gh_meta : dict[str, GhMeta], Optional
-            A dictionary mapping lowercased package names to the last known
-            good ``GhMeta`` name (e.g. loaded from the live packages.yml). Used as
-            a fallback so a single failed API call doesn't erase previously
-            collected metrics.
 
         Returns:
         -------
         dict
-            Updated review data with GitHub metrics.
+            Review data with freshly fetched ``gh_meta`` where the API
+            succeeded, or ``None`` where it did not.
         """
-        existing_gh_meta = existing_gh_meta or {}
-        stop_early = False
+        # if True, metrics run should stop further API fetches
+        stop_metrics_run = False
 
         for pkg_name, owner_repo in tqdm(
             endpoints.items(), desc="Fetching repo metadata"
@@ -302,44 +303,33 @@ class GitHubAPI:
                 review = reviews[pkg_name]
                 if review.repository_host != RepositoryHost.github:
                     logger.warning(
-                        f"Unsupported repository host for {pkg_name}: {review.repository_host}"
+                        f"Unsupported repository host for {pkg_name}: "
+                        f"{review.repository_host}"
                     )
                     continue
 
-                previous_meta = existing_gh_meta.get(pkg_name.lower())
-
-                new_meta = None
-                if not stop_early:
+                new_metadata = None
+                if not stop_metrics_run:
                     try:
-                        new_meta = self.get_repo_meta_github(owner_repo)
+                        new_metadata = self.get_repo_meta_github(owner_repo)
                     except GitHubAPIError as exc:
                         logger.error(
                             f"Stopping GitHub metrics run early: {exc} "
-                            "Remaining packages will fall back to previously "
-                            "saved metrics."
+                            "Remaining packages will keep empty gh_meta for "
+                            "gap-fill from previously saved metrics."
                         )
-                        stop_early = True
+                        stop_metrics_run = True
                     except Exception:
                         logger.warning(
-                            f"Unexpected error fetching GitHub metrics for {pkg_name}. "
-                            "Treating this package as a failed fetch.",
+                            f"Unexpected error fetching GitHub metrics for "
+                            f"{pkg_name}. Treating this package as a failed "
+                            "fetch.",
                             exc_info=True,
                         )
-                        new_meta = None
+                        new_metadata = None
 
-                if new_meta is not None:
-                    reviews[pkg_name].gh_meta = new_meta
-                elif previous_meta is not None:
-                    logger.warning(
-                        f"Couldn't refresh GitHub metrics for {pkg_name}. "
-                        "Using the previously saved metrics from packages.yml."
-                    )
-                    reviews[pkg_name].gh_meta = previous_meta
-                else:
-                    logger.warning(
-                        f"No GitHub metrics available for {pkg_name} "
-                        "(none saved previously, and this fetch failed)."
-                    )
+                if new_metadata is not None:
+                    reviews[pkg_name].gh_meta = new_metadata
 
         return reviews
 

--- a/src/pyosmeta/github_api.py
+++ b/src/pyosmeta/github_api.py
@@ -281,7 +281,7 @@ class GitHubAPI:
             A dictionary containing review data.
         existing_gh_meta : dict[str, GhMeta], Optional
             A dictionary mapping lowercased package names to the last known
-            good ``GhMeta`` (e.g. loaded from the live packages.yml). Used as
+            good ``GhMeta`` name (e.g. loaded from the live packages.yml). Used as
             a fallback so a single failed API call doesn't erase previously
             collected metrics.
 

--- a/src/pyosmeta/github_api.py
+++ b/src/pyosmeta/github_api.py
@@ -18,7 +18,7 @@ import requests
 from dotenv import load_dotenv
 
 from pyosmeta.models import ReviewModel
-from pyosmeta.models.base import RepositoryHost
+from pyosmeta.models.base import GhMeta, RepositoryHost
 
 from .logging import logger
 
@@ -186,6 +186,7 @@ class GitHubAPI:
         self,
         endpoints: dict[dict[str, str]],
         reviews: dict[str, ReviewModel],
+        existing_gh_meta: dict[str, GhMeta] | None = None,
     ) -> dict[str, ReviewModel]:
         """
         Get GitHub metrics for all reviews using provided repo name and owner.
@@ -197,22 +198,42 @@ class GitHubAPI:
             A dictionary mapping package names to their owner and repo-names.
         reviews : dict
             A dictionary containing review data.
+        existing_gh_meta : dict[str, GhMeta], Optional
+            A dictionary mapping lowercased package names to the last known
+            good ``GhMeta`` (e.g. loaded from the live packages.yml). Used as
+            a fallback so a single failed API call doesn't erase previously
+            collected metrics.
 
         Returns:
         -------
         dict
             Updated review data with GitHub metrics.
         """
+        existing_gh_meta = existing_gh_meta or {}
 
         for pkg_name, owner_repo in endpoints.items():
             review = reviews[pkg_name]
-            if review.repository_host == RepositoryHost.github:
-                reviews[pkg_name].gh_meta = self.get_repo_meta_github(
-                    owner_repo
-                )
-            else:
+            if review.repository_host != RepositoryHost.github:
                 logger.warning(
                     f"Unsupported repository host for {pkg_name}: {review.repository_host}"
+                )
+                continue
+
+            previous_meta = existing_gh_meta.get(pkg_name.lower())
+            new_meta = self.get_repo_meta_github(owner_repo)
+
+            if new_meta is not None:
+                reviews[pkg_name].gh_meta = new_meta
+            elif previous_meta is not None:
+                logger.warning(
+                    f"Couldn't refresh GitHub metrics for {pkg_name}. "
+                    "Using the previously saved metrics from packages.yml."
+                )
+                reviews[pkg_name].gh_meta = previous_meta
+            else:
+                logger.warning(
+                    f"No GitHub metrics available for {pkg_name} "
+                    "(none saved previously, and this fetch failed)."
                 )
 
         return reviews

--- a/src/pyosmeta/models/base.py
+++ b/src/pyosmeta/models/base.py
@@ -256,9 +256,7 @@ class GhMeta(BaseModel, UrlValidatorMixin):
     open_issues_count: int
     forks_count: int
     documentation: Optional[str]
-    # Optional because the contributors REST call can fail independently of
-    # the GraphQL call (e.g. a 404) - it shouldn't raise a ValidationError
-    # and take down metrics for the whole package when that happens.
+    # Optional in case the rest cal fails and we don't have new metrics
     contrib_count: Optional[int] = None
     last_commit: str
 

--- a/src/pyosmeta/models/base.py
+++ b/src/pyosmeta/models/base.py
@@ -256,7 +256,7 @@ class GhMeta(BaseModel, UrlValidatorMixin):
     open_issues_count: int
     forks_count: int
     documentation: Optional[str]
-    # Optional in case the rest cal fails and we don't have new metrics
+    # Optional in case the rest call fails and we don't have new metrics
     contrib_count: Optional[int] = None
     last_commit: str
 

--- a/src/pyosmeta/models/base.py
+++ b/src/pyosmeta/models/base.py
@@ -38,6 +38,7 @@ class RepositoryHost(str, Enum):
     github = "github"
     gitlab = "gitlab"
     codeberg = "codeberg"
+    bitbucket = "bitbucket"
 
     @classmethod
     def from_url(cls, url: str) -> "RepositoryHost":
@@ -59,6 +60,8 @@ class RepositoryHost(str, Enum):
             return cls.gitlab
         elif "codeberg.org" in url:
             return cls.codeberg
+        elif "bitbucket.org" in url:
+            return cls.bitbucket
         else:
             return cls.other
 

--- a/src/pyosmeta/models/base.py
+++ b/src/pyosmeta/models/base.py
@@ -253,7 +253,10 @@ class GhMeta(BaseModel, UrlValidatorMixin):
     open_issues_count: int
     forks_count: int
     documentation: Optional[str]
-    contrib_count: int
+    # Optional because the contributors REST call can fail independently of
+    # the GraphQL call (e.g. a 404) - it shouldn't raise a ValidationError
+    # and take down metrics for the whole package when that happens.
+    contrib_count: Optional[int] = None
     last_commit: str
 
     @field_validator(

--- a/src/pyosmeta/parse_issues.py
+++ b/src/pyosmeta/parse_issues.py
@@ -365,7 +365,6 @@ class ProcessIssues:
             models = models[0]
         return models
 
-    # TODO: This now returns a dict of owner:repo_name to support graphql
     def get_repo_paths(
         self, review_issues: dict[str, ReviewModel]
     ) -> dict[str, dict[str, str]]:

--- a/src/pyosmeta/utils_clean.py
+++ b/src/pyosmeta/utils_clean.py
@@ -50,25 +50,33 @@ def get_clean_user(username: str) -> str:
 def clean_date(source_date: str | None) -> datetime | str:
     """Cleans up a date string to a consistent datetime format.
 
-    The source date string may have been manually entered as month-day-year format,
-    retrieved from GitHub as a timestamp, could be missing, or contain random text.
-    This utility validates the input and returns a consistent format.
+    The source date string may have been manually entered as month-day-year
+    format, retrieved fresh from GitHub as a full timestamp, already cleaned
+    to ``YYYY-MM-DD`` (e.g. re-loaded from a previously exported
+    packages.yml), could be missing, or contain random text. This utility
+    validates the input and returns a consistent format.
+
+    Cleaning an already-cleaned date
+    should return the same value, since we re-parse previously exported
+    metrics as a fallback when a fresh GitHub API call fails (so the data aren't
+    deleted).
     """
 
     if source_date is None or source_date == "missing":
         return "missing"
-    else:
+
+    for fmt in ("%Y-%m-%dT%H:%M:%SZ", "%Y-%m-%d"):
         try:
             return (
-                datetime.strptime(source_date, "%Y-%m-%dT%H:%M:%SZ")
-                .date()
-                .strftime("%Y-%m-%d")
+                datetime.strptime(source_date, fmt).date().strftime("%Y-%m-%d")
             )
-        except TypeError:
-            logger.error(
-                "Oops - missing date. Setting date to 'missing'", exc_info=True
-            )
-            return "missing"
+        except (TypeError, ValueError):
+            continue
+
+    logger.error(
+        f"Oops - couldn't parse date '{source_date}'. Setting date to 'missing'"
+    )
+    return "missing"
 
 
 def clean_name(source_name: str) -> str:

--- a/tests/unit/test_get_metrics.py
+++ b/tests/unit/test_get_metrics.py
@@ -1,5 +1,6 @@
 import pytest
 
+from pyosmeta.cli.process_reviews import update_gh_meta
 from pyosmeta.github_api import GitHubAPI, GitHubAPIError
 from pyosmeta.models import ReviewModel
 from pyosmeta.models.base import GhMeta
@@ -53,77 +54,32 @@ def old_meta():
 
 
 class TestGetMetrics:
+    """Fetch-only behavior: get_metrics does not gap-fill from existing data."""
+
     def test_uses_fresh_data_when_fetch_succeeds(
-        self, mocker, review, endpoints, new_meta, old_meta
+        self, mocker, review, endpoints, new_meta
     ):
-        """A successful fetch should update gh_meta, even if we had
-        previously saved metrics for this package."""
         github_api = GitHubAPI()
         mocker.patch.object(
             github_api, "get_repo_meta_github", return_value=new_meta
         )
 
-        reviews = github_api.get_metrics(
-            endpoints, {"sunpy": review}, {"sunpy": old_meta}
-        )
+        reviews = github_api.get_metrics(endpoints, {"sunpy": review})
 
         assert reviews["sunpy"].gh_meta.stargazers_count == 999
 
-    def test_keeps_previous_data_when_fetch_fails(
-        self, mocker, review, endpoints, old_meta
-    ):
-        """If the API call fails (returns None), we must never delete
-        previously collected metrics."""
+    def test_leaves_none_when_fetch_fails(self, mocker, review, endpoints):
+        """Failed fetch leaves gh_meta empty; gap-fill is update_gh_meta's job."""
         github_api = GitHubAPI()
         mocker.patch.object(
             github_api, "get_repo_meta_github", return_value=None
         )
 
-        reviews = github_api.get_metrics(
-            endpoints, {"sunpy": review}, {"sunpy": old_meta}
-        )
-
-        assert reviews["sunpy"].gh_meta is not None
-        assert reviews["sunpy"].gh_meta.stargazers_count == 500
-
-    def test_existing_gh_meta_lookup_is_case_insensitive(
-        self, mocker, review, endpoints, old_meta
-    ):
-        """existing_gh_meta is keyed by lowercased package name (as
-        produced by file_io.load_website_yml), so lookups must lowercase
-        the package name too."""
-        github_api = GitHubAPI()
-        mocker.patch.object(
-            github_api, "get_repo_meta_github", return_value=None
-        )
-
-        reviews = github_api.get_metrics(
-            endpoints, {"sunpy": review}, {"SunPy".lower(): old_meta}
-        )
-
-        assert reviews["sunpy"].gh_meta.stargazers_count == 500
-
-    def test_no_data_when_fetch_fails_and_nothing_saved(
-        self, mocker, review, endpoints
-    ):
-        """If we've never successfully fetched metrics for a package and
-        the fetch fails, gh_meta should stay empty (nothing to lose)."""
-        github_api = GitHubAPI()
-        mocker.patch.object(
-            github_api, "get_repo_meta_github", return_value=None
-        )
-
-        reviews = github_api.get_metrics(endpoints, {"sunpy": review}, {})
+        reviews = github_api.get_metrics(endpoints, {"sunpy": review})
 
         assert reviews["sunpy"].gh_meta is None
 
-    def test_unexpected_exception_does_not_stop_the_batch(
-        self, mocker, review, endpoints, old_meta
-    ):
-        """An unexpected exception (e.g. a network error) from
-        get_repo_meta_github for one package must not crash the batch -
-        it should be treated like a failed fetch, falling back to
-        previously saved metrics."""
+    def test_unexpected_exception_leaves_none(self, mocker, review, endpoints):
         github_api = GitHubAPI()
         mocker.patch.object(
             github_api,
@@ -131,19 +87,13 @@ class TestGetMetrics:
             side_effect=RuntimeError("boom"),
         )
 
-        reviews = github_api.get_metrics(
-            endpoints, {"sunpy": review}, {"sunpy": old_meta}
-        )
+        reviews = github_api.get_metrics(endpoints, {"sunpy": review})
 
-        assert reviews["sunpy"].gh_meta is not None
-        assert reviews["sunpy"].gh_meta.stargazers_count == 500
+        assert reviews["sunpy"].gh_meta is None
 
-    def test_fatal_error_falls_back_for_current_package(
-        self, mocker, review, endpoints, old_meta
+    def test_fatal_error_leaves_none_for_current_package(
+        self, mocker, review, endpoints
     ):
-        """A GitHubAPIError (401 or rate-limit-exhausted 403) for a
-        package must not crash the batch - it should fall back to
-        previously saved metrics, just like any other failed fetch."""
         github_api = GitHubAPI()
         mocker.patch.object(
             github_api,
@@ -151,19 +101,13 @@ class TestGetMetrics:
             side_effect=GitHubAPIError("401 Unauthorized"),
         )
 
-        reviews = github_api.get_metrics(
-            endpoints, {"sunpy": review}, {"sunpy": old_meta}
-        )
+        reviews = github_api.get_metrics(endpoints, {"sunpy": review})
 
-        assert reviews["sunpy"].gh_meta is not None
-        assert reviews["sunpy"].gh_meta.stargazers_count == 500
+        assert reviews["sunpy"].gh_meta is None
 
     def test_fatal_error_stops_remaining_packages_from_being_fetched(
-        self, mocker, old_meta
+        self, mocker
     ):
-        """Once a GitHubAPIError occurs, no further API calls should be
-        made for remaining packages - they should go straight to fallback
-        (or stay empty if nothing was saved)."""
         endpoints = {
             "sunpy": {"owner": "sunpy", "repo_name": "sunpy"},
             "other-pkg": {"owner": "other", "repo_name": "other-pkg"},
@@ -185,16 +129,13 @@ class TestGetMetrics:
             side_effect=GitHubAPIError("403 rate limit exhausted"),
         )
 
-        reviews = github_api.get_metrics(
-            endpoints, reviews_input, {"sunpy": old_meta}
-        )
+        reviews = github_api.get_metrics(endpoints, reviews_input)
 
         mock_fetch.assert_called_once()
-        assert reviews["sunpy"].gh_meta.stargazers_count == 500
+        assert reviews["sunpy"].gh_meta is None
         assert reviews["other-pkg"].gh_meta is None
 
-    def test_skips_non_github_hosts(self, mocker, endpoints, old_meta):
-        """Non-GitHub repos should be skipped without touching gh_meta."""
+    def test_skips_non_github_hosts(self, mocker):
         review = ReviewModel(
             package_name="example",
             repository_link="https://gitlab.com/example/example",
@@ -205,8 +146,60 @@ class TestGetMetrics:
         reviews = github_api.get_metrics(
             {"example": {"owner": "example", "repo_name": "example"}},
             {"example": review},
-            {"example": old_meta},
         )
 
         mock_fetch.assert_not_called()
         assert reviews["example"].gh_meta is None
+
+
+class TestUpdateGhMeta:
+    """Gap-fill from previously published packages.yml after a fetch."""
+
+    def test_prefers_fresh_data(self, review, new_meta, old_meta):
+        review.gh_meta = GhMeta(**new_meta)
+
+        reviews = update_gh_meta({"sunpy": old_meta}, {"sunpy": review})
+
+        assert reviews["sunpy"].gh_meta.stargazers_count == 999
+
+    def test_fills_from_existing_when_fetch_left_none(self, review, old_meta):
+        assert review.gh_meta is None
+
+        reviews = update_gh_meta({"sunpy": old_meta}, {"sunpy": review})
+
+        assert reviews["sunpy"].gh_meta is not None
+        assert reviews["sunpy"].gh_meta.stargazers_count == 500
+
+    def test_existing_lookup_is_case_insensitive(self, old_meta):
+        """existing_gh_meta keys are lowercased; review keys may not be."""
+        review = ReviewModel(
+            package_name="SunPy",
+            repository_link="https://github.com/sunpy/sunpy",
+        )
+
+        reviews = update_gh_meta({"sunpy": old_meta}, {"SunPy": review})
+
+        assert reviews["SunPy"].gh_meta.stargazers_count == 500
+
+    def test_leaves_none_when_nothing_saved(self, review):
+        reviews = update_gh_meta({}, {"sunpy": review})
+
+        assert reviews["sunpy"].gh_meta is None
+
+    def test_gap_fills_after_fatal_stop(self, old_meta):
+        """Simulate get_metrics stop: both packages None, then merge fills."""
+        reviews = {
+            "sunpy": ReviewModel(
+                package_name="sunpy",
+                repository_link="https://github.com/sunpy/sunpy",
+            ),
+            "other-pkg": ReviewModel(
+                package_name="other-pkg",
+                repository_link="https://github.com/other/other-pkg",
+            ),
+        }
+
+        reviews = update_gh_meta({"sunpy": old_meta}, reviews)
+
+        assert reviews["sunpy"].gh_meta.stargazers_count == 500
+        assert reviews["other-pkg"].gh_meta is None

--- a/tests/unit/test_get_metrics.py
+++ b/tests/unit/test_get_metrics.py
@@ -117,6 +117,27 @@ class TestGetMetrics:
 
         assert reviews["sunpy"].gh_meta is None
 
+    def test_unexpected_exception_does_not_stop_the_batch(
+        self, mocker, review, endpoints, old_meta
+    ):
+        """An unexpected exception (e.g. a network error) from
+        get_repo_meta_github for one package must not crash the batch -
+        it should be treated like a failed fetch, falling back to
+        previously saved metrics."""
+        github_api = GitHubAPI()
+        mocker.patch.object(
+            github_api,
+            "get_repo_meta_github",
+            side_effect=RuntimeError("boom"),
+        )
+
+        reviews = github_api.get_metrics(
+            endpoints, {"sunpy": review}, {"sunpy": old_meta}
+        )
+
+        assert reviews["sunpy"].gh_meta is not None
+        assert reviews["sunpy"].gh_meta.stargazers_count == 500
+
     def test_skips_non_github_hosts(self, mocker, endpoints, old_meta):
         """Non-GitHub repos should be skipped without touching gh_meta."""
         review = ReviewModel(

--- a/tests/unit/test_get_metrics.py
+++ b/tests/unit/test_get_metrics.py
@@ -1,6 +1,6 @@
 import pytest
 
-from pyosmeta.github_api import GitHubAPI
+from pyosmeta.github_api import GitHubAPI, GitHubAPIError
 from pyosmeta.models import ReviewModel
 from pyosmeta.models.base import GhMeta
 
@@ -137,6 +137,61 @@ class TestGetMetrics:
 
         assert reviews["sunpy"].gh_meta is not None
         assert reviews["sunpy"].gh_meta.stargazers_count == 500
+
+    def test_fatal_error_falls_back_for_current_package(
+        self, mocker, review, endpoints, old_meta
+    ):
+        """A GitHubAPIError (401 or rate-limit-exhausted 403) for a
+        package must not crash the batch - it should fall back to
+        previously saved metrics, just like any other failed fetch."""
+        github_api = GitHubAPI()
+        mocker.patch.object(
+            github_api,
+            "get_repo_meta_github",
+            side_effect=GitHubAPIError("401 Unauthorized"),
+        )
+
+        reviews = github_api.get_metrics(
+            endpoints, {"sunpy": review}, {"sunpy": old_meta}
+        )
+
+        assert reviews["sunpy"].gh_meta is not None
+        assert reviews["sunpy"].gh_meta.stargazers_count == 500
+
+    def test_fatal_error_stops_remaining_packages_from_being_fetched(
+        self, mocker, old_meta
+    ):
+        """Once a GitHubAPIError occurs, no further API calls should be
+        made for remaining packages - they should go straight to fallback
+        (or stay empty if nothing was saved)."""
+        endpoints = {
+            "sunpy": {"owner": "sunpy", "repo_name": "sunpy"},
+            "other-pkg": {"owner": "other", "repo_name": "other-pkg"},
+        }
+        reviews_input = {
+            "sunpy": ReviewModel(
+                package_name="sunpy",
+                repository_link="https://github.com/sunpy/sunpy",
+            ),
+            "other-pkg": ReviewModel(
+                package_name="other-pkg",
+                repository_link="https://github.com/other/other-pkg",
+            ),
+        }
+        github_api = GitHubAPI()
+        mock_fetch = mocker.patch.object(
+            github_api,
+            "get_repo_meta_github",
+            side_effect=GitHubAPIError("403 rate limit exhausted"),
+        )
+
+        reviews = github_api.get_metrics(
+            endpoints, reviews_input, {"sunpy": old_meta}
+        )
+
+        mock_fetch.assert_called_once()
+        assert reviews["sunpy"].gh_meta.stargazers_count == 500
+        assert reviews["other-pkg"].gh_meta is None
 
     def test_skips_non_github_hosts(self, mocker, endpoints, old_meta):
         """Non-GitHub repos should be skipped without touching gh_meta."""

--- a/tests/unit/test_get_metrics.py
+++ b/tests/unit/test_get_metrics.py
@@ -1,0 +1,136 @@
+import pytest
+
+from pyosmeta.github_api import GitHubAPI
+from pyosmeta.models import ReviewModel
+from pyosmeta.models.base import GhMeta
+
+
+@pytest.fixture
+def review():
+    return ReviewModel(
+        package_name="sunpy",
+        repository_link="https://github.com/sunpy/sunpy",
+    )
+
+
+@pytest.fixture
+def endpoints():
+    return {"sunpy": {"owner": "sunpy", "repo_name": "sunpy"}}
+
+
+@pytest.fixture
+def new_meta():
+    """A freshly fetched gh_meta dict, as returned by get_repo_meta_github."""
+    return {
+        "name": "sunpy",
+        "description": "Python for Solar Physics",
+        "created_at": "2013-01-01",
+        "stargazers_count": 999,
+        "watchers_count": 10,
+        "open_issues_count": 5,
+        "forks_count": 100,
+        "documentation": "https://sunpy.org",
+        "contrib_count": 200,
+        "last_commit": "2026-01-01",
+    }
+
+
+@pytest.fixture
+def old_meta():
+    """Previously saved metrics, as loaded from the live packages.yml."""
+    return GhMeta(
+        name="sunpy",
+        description="Python for Solar Physics",
+        created_at="2013-01-01",
+        stargazers_count=500,
+        watchers_count=8,
+        open_issues_count=3,
+        forks_count=90,
+        documentation="https://sunpy.org",
+        contrib_count=150,
+        last_commit="2025-01-01",
+    )
+
+
+class TestGetMetrics:
+    def test_uses_fresh_data_when_fetch_succeeds(
+        self, mocker, review, endpoints, new_meta, old_meta
+    ):
+        """A successful fetch should update gh_meta, even if we had
+        previously saved metrics for this package."""
+        github_api = GitHubAPI()
+        mocker.patch.object(
+            github_api, "get_repo_meta_github", return_value=new_meta
+        )
+
+        reviews = github_api.get_metrics(
+            endpoints, {"sunpy": review}, {"sunpy": old_meta}
+        )
+
+        assert reviews["sunpy"].gh_meta.stargazers_count == 999
+
+    def test_keeps_previous_data_when_fetch_fails(
+        self, mocker, review, endpoints, old_meta
+    ):
+        """If the API call fails (returns None), we must never delete
+        previously collected metrics."""
+        github_api = GitHubAPI()
+        mocker.patch.object(
+            github_api, "get_repo_meta_github", return_value=None
+        )
+
+        reviews = github_api.get_metrics(
+            endpoints, {"sunpy": review}, {"sunpy": old_meta}
+        )
+
+        assert reviews["sunpy"].gh_meta is not None
+        assert reviews["sunpy"].gh_meta.stargazers_count == 500
+
+    def test_existing_gh_meta_lookup_is_case_insensitive(
+        self, mocker, review, endpoints, old_meta
+    ):
+        """existing_gh_meta is keyed by lowercased package name (as
+        produced by file_io.load_website_yml), so lookups must lowercase
+        the package name too."""
+        github_api = GitHubAPI()
+        mocker.patch.object(
+            github_api, "get_repo_meta_github", return_value=None
+        )
+
+        reviews = github_api.get_metrics(
+            endpoints, {"sunpy": review}, {"SunPy".lower(): old_meta}
+        )
+
+        assert reviews["sunpy"].gh_meta.stargazers_count == 500
+
+    def test_no_data_when_fetch_fails_and_nothing_saved(
+        self, mocker, review, endpoints
+    ):
+        """If we've never successfully fetched metrics for a package and
+        the fetch fails, gh_meta should stay empty (nothing to lose)."""
+        github_api = GitHubAPI()
+        mocker.patch.object(
+            github_api, "get_repo_meta_github", return_value=None
+        )
+
+        reviews = github_api.get_metrics(endpoints, {"sunpy": review}, {})
+
+        assert reviews["sunpy"].gh_meta is None
+
+    def test_skips_non_github_hosts(self, mocker, endpoints, old_meta):
+        """Non-GitHub repos should be skipped without touching gh_meta."""
+        review = ReviewModel(
+            package_name="example",
+            repository_link="https://gitlab.com/example/example",
+        )
+        github_api = GitHubAPI()
+        mock_fetch = mocker.patch.object(github_api, "get_repo_meta_github")
+
+        reviews = github_api.get_metrics(
+            {"example": {"owner": "example", "repo_name": "example"}},
+            {"example": review},
+            {"example": old_meta},
+        )
+
+        mock_fetch.assert_not_called()
+        assert reviews["example"].gh_meta is None

--- a/tests/unit/test_githubapi.py
+++ b/tests/unit/test_githubapi.py
@@ -5,7 +5,7 @@ import secrets
 import pytest
 
 from pyosmeta import github_api
-from pyosmeta.github_api import GitHubAPI
+from pyosmeta.github_api import GitHubAPI, GitHubAPIError
 from pyosmeta.models.base import GhMeta
 
 
@@ -270,11 +270,12 @@ def test_get_metrics_rest_not_found(mocker, caplog):
     assert "Repository not found" in caplog.text
 
 
-def test_get_metrics_rest_forbidden(mocker, caplog):
-    """Test that a 403 response returns None and logs a warning."""
+def test_get_metrics_rest_forbidden_permission_denied(mocker, caplog):
+    """Test that a 403 without an exhausted rate limit (e.g. a private or
+    blocked repo) returns None and logs a warning, without raising."""
     mock_response = mocker.Mock()
     mock_response.status_code = 403
-    mock_response.text = "rate limited"
+    mock_response.text = "permission denied"
     mock_response.headers = {}
     mocker.patch("requests.get", return_value=mock_response)
 
@@ -286,7 +287,42 @@ def test_get_metrics_rest_forbidden(mocker, caplog):
         )
 
     assert metrics is None
-    assert "API limit" in caplog.text
+    assert "Forbidden" in caplog.text
+
+
+def test_get_metrics_rest_forbidden_rate_limit_exhausted(mocker):
+    """Test that a 403 with X-RateLimit-Remaining: 0 raises GitHubAPIError
+    instead of being treated as a single-package failure."""
+    mock_response = mocker.Mock()
+    mock_response.status_code = 403
+    mock_response.text = "rate limited"
+    mock_response.headers = {
+        "X-RateLimit-Remaining": "0",
+        "X-RateLimit-Reset": "1700000000",
+    }
+    mocker.patch("requests.get", return_value=mock_response)
+
+    github_api = GitHubAPI()
+
+    with pytest.raises(GitHubAPIError, match="rate limit exhausted"):
+        github_api._get_metrics_rest(
+            {"owner": "pyopensci", "repo_name": "pyosmeta"}
+        )
+
+
+def test_get_metrics_rest_unauthorized(mocker):
+    """Test that a 401 raises GitHubAPIError instead of being treated
+    as a single-package failure."""
+    mock_response = mocker.Mock()
+    mock_response.status_code = 401
+    mocker.patch("requests.get", return_value=mock_response)
+
+    github_api = GitHubAPI()
+
+    with pytest.raises(GitHubAPIError, match="401 Unauthorized"):
+        github_api._get_metrics_rest(
+            {"owner": "pyopensci", "repo_name": "pyosmeta"}
+        )
 
 
 def test_get_metrics_rest_unexpected_error(mocker, caplog):
@@ -306,9 +342,41 @@ def test_get_metrics_rest_unexpected_error(mocker, caplog):
     assert "Unexpected HTTP error" in caplog.text
 
 
+def test_get_contrib_count_rest_successful(mocker):
+    """Test that the contributor count matches the length of the
+    contributors list returned by _get_response_rest."""
+    github_api = GitHubAPI()
+    mocker.patch.object(
+        github_api,
+        "_get_response_rest",
+        return_value=[{"login": "a"}, {"login": "b"}, {"login": "c"}],
+    )
+
+    count = github_api._get_contrib_count_rest(
+        {"owner": "pyopensci", "repo_name": "pyosmeta"}
+    )
+
+    assert count == 3
+
+
+def test_get_contrib_count_rest_no_contributors(mocker, caplog):
+    """Test that an empty contributors list returns None and logs a
+    warning."""
+    github_api = GitHubAPI()
+    mocker.patch.object(github_api, "_get_response_rest", return_value=[])
+
+    with caplog.at_level(logging.WARNING):
+        count = github_api._get_contrib_count_rest(
+            {"owner": "pyopensci", "repo_name": "pyosmeta"}
+        )
+
+    assert count is None
+    assert "Repository not found" in caplog.text
+
+
 def test_get_repo_meta_github_is_rest_first(mocker):
-    """Test that get_repo_meta_github uses REST for metadata (not GraphQL)
-    and merges in contrib_count from the separate contributors call."""
+    """Test that get_repo_meta_github uses REST for metadata and merges in
+    contrib_count from the separate contributors call."""
     github_api = GitHubAPI()
     rest_metrics = {
         "name": "pyosmeta",
@@ -324,7 +392,6 @@ def test_get_repo_meta_github_is_rest_first(mocker):
     mock_rest = mocker.patch.object(
         github_api, "_get_metrics_rest", return_value=dict(rest_metrics)
     )
-    mock_graphql = mocker.patch.object(github_api, "_get_metrics_graphql")
     mock_contrib = mocker.patch.object(
         github_api, "_get_contrib_count_rest", return_value=7
     )
@@ -336,7 +403,6 @@ def test_get_repo_meta_github_is_rest_first(mocker):
     mock_rest.assert_called_once_with(
         {"owner": "pyopensci", "repo_name": "pyosmeta"}
     )
-    mock_graphql.assert_not_called()
     mock_contrib.assert_called_once_with(
         {"owner": "pyopensci", "repo_name": "pyosmeta"}
     )

--- a/tests/unit/test_githubapi.py
+++ b/tests/unit/test_githubapi.py
@@ -1,3 +1,4 @@
+import logging
 import os
 import secrets
 
@@ -5,6 +6,7 @@ import pytest
 
 from pyosmeta import github_api
 from pyosmeta.github_api import GitHubAPI
+from pyosmeta.models.base import GhMeta
 
 
 @pytest.fixture
@@ -170,3 +172,131 @@ def test_get_user_info_bad_credentials(mocker):
 
     with pytest.raises(ValueError, match="Oops, I couldn't authenticate"):
         github_api.get_user_info("example_user")
+
+
+def test_gh_meta_field_mapping_matches_model_fields():
+    """Ensure GhMeta field mapping stays aligned with the model.
+
+    This test makes sure that all required GhMeta fields are accounted for and
+    that non-contributor fields have an explicit REST source mapping.
+    """
+    mapping = GitHubAPI.get_gh_meta_field_mapping()
+
+    required_fields = set(mapping["required_fields"])
+    model_fields = set(GhMeta.model_fields.keys())
+    mapped_fields = set(mapping["rest_field_map"].keys())
+
+    assert required_fields == model_fields
+    assert required_fields == mapped_fields.union({"contrib_count"})
+    assert mapping["last_commit_source"] == "pushed_at"
+    assert mapping["contrib_source"] == "GET /repos/{owner}/{repo}/contributors"
+
+
+@pytest.fixture
+def rest_repo_response():
+    """A representative GET /repos/{owner}/{repo} payload."""
+    return {
+        "name": "pyosmeta",
+        "description": "A package for pyOS metadata.",
+        "homepage": "https://example.com/docs",
+        "created_at": "2020-01-01T00:00:00Z",
+        "stargazers_count": 42,
+        "watchers_count": 42,
+        "open_issues_count": 3,
+        "forks_count": 5,
+        "pushed_at": "2024-06-01T00:00:00Z",
+    }
+
+
+def test_get_metrics_rest_successful(mocker, rest_repo_response):
+    """Test that a 200 response is normalized to GhMeta-compatible keys."""
+    mock_response = mocker.Mock()
+    mock_response.status_code = 200
+    mock_response.json.return_value = rest_repo_response
+    mocker.patch("requests.get", return_value=mock_response)
+
+    github_api = GitHubAPI()
+    metrics = github_api._get_metrics_rest(
+        {"owner": "pyopensci", "repo_name": "pyosmeta"}
+    )
+
+    assert metrics == {
+        "name": "pyosmeta",
+        "description": "A package for pyOS metadata.",
+        "documentation": "https://example.com/docs",
+        "created_at": "2020-01-01T00:00:00Z",
+        "stargazers_count": 42,
+        "watchers_count": 42,
+        "open_issues_count": 3,
+        "forks_count": 5,
+        "last_commit": "2024-06-01T00:00:00Z",
+    }
+
+
+def test_get_metrics_rest_normalizes_empty_homepage(mocker, rest_repo_response):
+    """Test that an empty-string homepage is normalized to None."""
+    rest_repo_response["homepage"] = ""
+    mock_response = mocker.Mock()
+    mock_response.status_code = 200
+    mock_response.json.return_value = rest_repo_response
+    mocker.patch("requests.get", return_value=mock_response)
+
+    github_api = GitHubAPI()
+    metrics = github_api._get_metrics_rest(
+        {"owner": "pyopensci", "repo_name": "pyosmeta"}
+    )
+
+    assert metrics["documentation"] is None
+
+
+def test_get_metrics_rest_not_found(mocker, caplog):
+    """Test that a 404 response returns None and logs a warning."""
+    mock_response = mocker.Mock()
+    mock_response.status_code = 404
+    mocker.patch("requests.get", return_value=mock_response)
+
+    github_api = GitHubAPI()
+
+    with caplog.at_level(logging.WARNING):
+        metrics = github_api._get_metrics_rest(
+            {"owner": "pyopensci", "repo_name": "missing-repo"}
+        )
+
+    assert metrics is None
+    assert "Repository not found" in caplog.text
+
+
+def test_get_metrics_rest_forbidden(mocker, caplog):
+    """Test that a 403 response returns None and logs a warning."""
+    mock_response = mocker.Mock()
+    mock_response.status_code = 403
+    mock_response.text = "rate limited"
+    mock_response.headers = {}
+    mocker.patch("requests.get", return_value=mock_response)
+
+    github_api = GitHubAPI()
+
+    with caplog.at_level(logging.WARNING):
+        metrics = github_api._get_metrics_rest(
+            {"owner": "pyopensci", "repo_name": "pyosmeta"}
+        )
+
+    assert metrics is None
+    assert "API limit" in caplog.text
+
+
+def test_get_metrics_rest_unexpected_error(mocker, caplog):
+    """Test that an unexpected status code returns None and logs a warning."""
+    mock_response = mocker.Mock()
+    mock_response.status_code = 500
+    mocker.patch("requests.get", return_value=mock_response)
+
+    github_api = GitHubAPI()
+
+    with caplog.at_level(logging.WARNING):
+        metrics = github_api._get_metrics_rest(
+            {"owner": "pyopensci", "repo_name": "pyosmeta"}
+        )
+
+    assert metrics is None
+    assert "Unexpected HTTP error" in caplog.text

--- a/tests/unit/test_githubapi.py
+++ b/tests/unit/test_githubapi.py
@@ -189,7 +189,9 @@ def test_gh_meta_field_mapping_matches_model_fields():
     assert required_fields == model_fields
     assert required_fields == mapped_fields.union({"contrib_count"})
     assert mapping["last_commit_source"] == "pushed_at"
-    assert mapping["contrib_source"] == "GET /repos/{owner}/{repo}/contributors"
+    assert (
+        mapping["contrib_source"] == "GET /repos/{owner}/{repo}/contributors"
+    )
 
 
 @pytest.fixture
@@ -233,7 +235,9 @@ def test_get_metrics_rest_successful(mocker, rest_repo_response):
     }
 
 
-def test_get_metrics_rest_normalizes_empty_homepage(mocker, rest_repo_response):
+def test_get_metrics_rest_normalizes_empty_homepage(
+    mocker, rest_repo_response
+):
     """Test that an empty-string homepage is normalized to None."""
     rest_repo_response["homepage"] = ""
     mock_response = mocker.Mock()
@@ -300,3 +304,55 @@ def test_get_metrics_rest_unexpected_error(mocker, caplog):
 
     assert metrics is None
     assert "Unexpected HTTP error" in caplog.text
+
+
+def test_get_repo_meta_github_is_rest_first(mocker):
+    """Test that get_repo_meta_github uses REST for metadata (not GraphQL)
+    and merges in contrib_count from the separate contributors call."""
+    github_api = GitHubAPI()
+    rest_metrics = {
+        "name": "pyosmeta",
+        "description": "A package for pyOS metadata.",
+        "documentation": None,
+        "created_at": "2020-01-01T00:00:00Z",
+        "stargazers_count": 42,
+        "watchers_count": 42,
+        "open_issues_count": 3,
+        "forks_count": 5,
+        "last_commit": "2024-06-01T00:00:00Z",
+    }
+    mock_rest = mocker.patch.object(
+        github_api, "_get_metrics_rest", return_value=dict(rest_metrics)
+    )
+    mock_graphql = mocker.patch.object(github_api, "_get_metrics_graphql")
+    mock_contrib = mocker.patch.object(
+        github_api, "_get_contrib_count_rest", return_value=7
+    )
+
+    metrics = github_api.get_repo_meta_github(
+        {"owner": "pyopensci", "repo_name": "pyosmeta"}
+    )
+
+    mock_rest.assert_called_once_with(
+        {"owner": "pyopensci", "repo_name": "pyosmeta"}
+    )
+    mock_graphql.assert_not_called()
+    mock_contrib.assert_called_once_with(
+        {"owner": "pyopensci", "repo_name": "pyosmeta"}
+    )
+    assert metrics == {**rest_metrics, "contrib_count": 7}
+
+
+def test_get_repo_meta_github_returns_none_when_rest_fails(mocker):
+    """Test that a failed REST fetch returns None without calling the
+    contributors endpoint."""
+    github_api = GitHubAPI()
+    mocker.patch.object(github_api, "_get_metrics_rest", return_value=None)
+    mock_contrib = mocker.patch.object(github_api, "_get_contrib_count_rest")
+
+    metrics = github_api.get_repo_meta_github(
+        {"owner": "pyopensci", "repo_name": "pyosmeta"}
+    )
+
+    assert metrics is None
+    mock_contrib.assert_not_called()

--- a/tests/unit/test_githubapi_return_response_rest.py
+++ b/tests/unit/test_githubapi_return_response_rest.py
@@ -4,7 +4,7 @@ from unittest.mock import Mock, patch
 import pytest
 import requests
 
-from pyosmeta.github_api import GitHubAPI
+from pyosmeta.github_api import GitHubAPI, GitHubAPIError
 
 
 class TestGitHubAPI:
@@ -85,19 +85,41 @@ class TestGitHubAPI:
             self.mock_get.return_value
         )
 
-    def test_unauthorized_request(self, caplog):
-        """Test handling of an unauthorized (401) response."""
+    def test_unauthorized_request(self):
+        """Test that a 401 response raises GitHubAPIError instead of
+        being silently swallowed."""
         self.mock_get.return_value.status_code = 401
-        self.mock_get.return_value.raise_for_status.side_effect = (
-            requests.HTTPError(response=self.mock_get.return_value)
-        )
+
+        with pytest.raises(GitHubAPIError, match="401 Unauthorized"):
+            self.api._get_response_rest("https://api.github.com/repos/test")
+
+    def test_forbidden_rate_limit_exhausted(self):
+        """Test that a 403 with X-RateLimit-Remaining: 0 raises
+        GitHubAPIError."""
+        self.mock_get.return_value.status_code = 403
+        self.mock_get.return_value.text = "rate limited"
+        self.mock_get.return_value.headers = {
+            "X-RateLimit-Remaining": "0",
+            "X-RateLimit-Reset": "1700000000",
+        }
+
+        with pytest.raises(GitHubAPIError, match="rate limit exhausted"):
+            self.api._get_response_rest("https://api.github.com/repos/test")
+
+    def test_forbidden_permission_denied(self, caplog):
+        """Test that a 403 without an exhausted rate limit returns the
+        results collected so far and logs a warning, without raising."""
+        self.mock_get.return_value.status_code = 403
+        self.mock_get.return_value.text = "permission denied"
+        self.mock_get.return_value.headers = {}
 
         with caplog.at_level(logging.WARNING):
             result = self.api._get_response_rest(
                 "https://api.github.com/repos/test"
             )
-            assert result == []
-            assert "Unauthorized request." in caplog.text
+
+        assert result == []
+        assert "Forbidden" in caplog.text
 
     def test_general_http_error(self):
         """Test handling of a general HTTP error (e.g., 500)."""

--- a/tests/unit/test_utils_clean.py
+++ b/tests/unit/test_utils_clean.py
@@ -24,7 +24,7 @@ from pyosmeta.utils_clean import (
         # Test cases for missing dates
         (None, "missing"),
         ("missing", "missing"),
-        # Unparseable input shouldn't raise, just fall back to "missing"
+        # Unparsable input shouldn't raise, just fall back to "missing"
         ("not-a-date", "missing"),
     ],
 )

--- a/tests/unit/test_utils_clean.py
+++ b/tests/unit/test_utils_clean.py
@@ -17,9 +17,15 @@ from pyosmeta.utils_clean import (
         # Test cases for valid dates
         ("2024-03-07T12:34:56Z", "2024-03-07"),
         ("2024-02-28T00:00:00Z", "2024-02-28"),
+        # Already-cleaned dates (e.g. re-loaded from a previous
+        # packages.yml export) must round-trip unchanged.
+        ("2024-03-07", "2024-03-07"),
+        ("2024-02-28", "2024-02-28"),
         # Test cases for missing dates
         (None, "missing"),
         ("missing", "missing"),
+        # Unparseable input shouldn't raise, just fall back to "missing"
+        ("not-a-date", "missing"),
     ],
 )
 def test_clean_date(input_date, expected_output):


### PR DESCRIPTION
closes #380  

This specific pr fixes some bugs with collecting metadata for a package repository. The API enpoints and token requirements have changed. 
This 

* moves things to rest from graphql meaning we don't have to worry about elevated permissions
* Adds more specific failure points when we hit a 401, 403 so it's clear the points of failure.

IT adds Basic api defensive checks. 

It also ensures that metadata are never deleted by loading previous data from the ex packages.yml file first, just like we do with contributor data. 