### PR TITLE
fix: Remove partnerships noise from cli output and add tqdm to metrics 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ See [GitHub releases](https://github.com/pyOpenSci/pyosMeta/releases) page for a
 
 ## [Unreleased]
 
+* Feat: add tqdm progress bar to parse issues workflow & remove community heading noise (@lwasser, #385)
 * Fix: permissions issue in reusable workflow
 
 ## [v1.7.9] - 2026-08-05

--- a/src/pyosmeta/github_api.py
+++ b/src/pyosmeta/github_api.py
@@ -16,6 +16,8 @@ from typing import Any, Optional, Union
 
 import requests
 from dotenv import load_dotenv
+from tqdm import tqdm
+from tqdm.contrib.logging import logging_redirect_tqdm
 
 from pyosmeta.models import ReviewModel
 from pyosmeta.models.base import RepositoryHost
@@ -204,16 +206,19 @@ class GitHubAPI:
             Updated review data with GitHub metrics.
         """
 
-        for pkg_name, owner_repo in endpoints.items():
-            review = reviews[pkg_name]
-            if review.repository_host == RepositoryHost.github:
-                reviews[pkg_name].gh_meta = self.get_repo_meta_github(
-                    owner_repo
-                )
-            else:
-                logger.warning(
-                    f"Unsupported repository host for {pkg_name}: {review.repository_host}"
-                )
+        for pkg_name, owner_repo in tqdm(
+            endpoints.items(), desc="Fetching repo metadata"
+        ):
+            with logging_redirect_tqdm():
+                review = reviews[pkg_name]
+                if review.repository_host == RepositoryHost.github:
+                    reviews[pkg_name].gh_meta = self.get_repo_meta_github(
+                        owner_repo
+                    )
+                else:
+                    logger.warning(
+                        f"Unsupported repository host for {pkg_name}: {review.repository_host}"
+                    )
 
         return reviews
 

--- a/src/pyosmeta/parse_issues.py
+++ b/src/pyosmeta/parse_issues.py
@@ -207,7 +207,7 @@ class ProcessIssues:
         # this could be made more flexible if it just runs until it runs
         # out of categories to parse
         meta["partners"] = self.get_categories(
-            body, "## Community Partnerships", 3, keyed=True
+            body, "## Community Partnerships", 3, keyed=True, optional=True
         )
         if "joss_doi" in meta:
             # Normalize the JOSS archive field. Some issues use `JOSS DOI` others `JOSS`
@@ -400,6 +400,7 @@ class ProcessIssues:
         section_str: str,
         num_vals: int,
         keyed: bool = False,
+        optional: bool = False,
     ) -> list[str] | None:
         """Parse through a pyOS review issue and grab categories associated
         with a package
@@ -423,13 +424,20 @@ class ProcessIssues:
             (and just extract the key).
 
             eg. ``- [x] Astropy: some other text`` would be parsed as ``'astropy'``
+
+        optional : bool
+            If True, the section is expected to be missing from some issues
+            (e.g. a newer template field older reviews won't have), so a
+            missing section is silently returned as None instead of logging
+            a warning.
         """
         # Find the starting index of the category section
         index = [
             i for i, sublist in enumerate(issue_list) if section_str in sublist
         ]
         if len(index) == 0:
-            logger.warning(f"{section_str} not found in the list")
+            if not optional:
+                logger.warning(f"{section_str} not found in the list")
             return None
         index = index[0]
 

--- a/tests/integration/test_parse_issues.py
+++ b/tests/integration/test_parse_issues.py
@@ -135,12 +135,15 @@ def test_missing_community_partnerships(caplog, process_issues, data_file):
     """
     Test handling of issues with a missing "## Community Partnerships" section.
 
-    This is a smoke test to ensure graceful handling of this case.
+    This section is optional (a newer template field many older reviews
+    lack), so a missing section should be handled gracefully and silently -
+    no warning logged.
     """
     review = data_file("reviews/missing_community_partnerships.txt", True)
     with caplog.at_level(logging.WARNING):
         review = process_issues.parse_issue(review)
-    assert "## Community Partnerships not found in the list" in caplog.text
+    assert review.partners is None
+    assert "## Community Partnerships not found in the list" not in caplog.text
 
 
 def test_multiple_editors_and_eic(process_issues, data_file):


### PR DESCRIPTION
This is a tiny fix that cleans up output at the CLI